### PR TITLE
Add dependency-version requirement for TileDB-Py

### DIFF
--- a/apis/python/README.md
+++ b/apis/python/README.md
@@ -12,6 +12,9 @@ This is test code for reading ANN data and writing into a TileDB nested group st
 
 # Installation
 
+This requires [`tiledb`](https://github.com/TileDB-Inc/TileDB-Py) 0.14.1 or above, in addition to other dependencies
+in [setup.cfg](./setup.cfg).
+
 After `cd` to `apis/python`:
 
 ```
@@ -25,6 +28,8 @@ python -m venv venv
 . ./venv/bin/activate
 pip install .
 ```
+
+Then:
 
 ```
 python -m pytest tests

--- a/apis/python/setup.cfg
+++ b/apis/python/setup.cfg
@@ -32,7 +32,7 @@ zip_safe = False
 # The numpy pin is to avoid
 # "ImportError: Numba needs NumPy 1.21 or less"
 install_requires =
-    tiledb
+    tiledb>=0.14.1
     scipy
     numpy<1.22
     pandas


### PR DESCRIPTION
Note `TileDB-Py` `0.14.1` or higher.