### PR TITLE
Add config/context to python scgroup class

### DIFF
--- a/apis/python/src/tiledbsc/util_tiledb.py
+++ b/apis/python/src/tiledbsc/util_tiledb.py
@@ -2,8 +2,9 @@
 
 import sys, os
 import tiledb
+from typing import Optional
 
-def show_single_cell_group(uri: str):
+def show_single_cell_group(uri: str, ctx: Optional[tiledb.Ctx] = None):
     """
     Show some summary information about an ingested TileDB Single-Cell Group.
     This tool goes a bit beyond
@@ -13,7 +14,7 @@ def show_single_cell_group(uri: str):
 
     print('================================================================')
     print('X/data:')
-    with tiledb.open(os.path.join(uri, 'X', 'data')) as A:
+    with tiledb.open(os.path.join(uri, 'X', 'data'), ctx=ctx) as A:
         df = A[:]
         print("keys", list(df.keys()))
         print(df)
@@ -21,7 +22,7 @@ def show_single_cell_group(uri: str):
 
     # Not all groups have raw X data
     try:
-        with tiledb.open(uri+'/X/raw') as A:
+        with tiledb.open(uri+'/X/raw', ctx=ctx) as A:
             print('X/raw:')
             df = A[:]
             print("keys", list(df.keys()))
@@ -32,26 +33,26 @@ def show_single_cell_group(uri: str):
 
     print('----------------------------------------------------------------')
     print('obs:')
-    with tiledb.open(os.path.join(uri, 'obs')) as A:
+    with tiledb.open(os.path.join(uri, 'obs'), ctx=ctx) as A:
         df = A[:]
         print("keys", list(df.keys()))
         print(A.schema)
 
     print('----------------------------------------------------------------')
     print('var:')
-    with tiledb.open(os.path.join(uri, 'var')) as A:
+    with tiledb.open(os.path.join(uri, 'var'), ctx=ctx) as A:
         df = A[:]
         print("keys", list(df.keys()))
         print(A.schema)
 
     for name in ['obsm', 'varm', 'obsp', 'varp']:
         try:
-            grp = tiledb.Group(os.path.join(uri, name), 'r')
+            grp = tiledb.Group(os.path.join(uri, name), mode='r', ctx=ctx)
             print()
             print('----------------------------------------------------------------')
             print(name, ':', sep='')
             for element in grp:
-                with tiledb.open(element.uri) as A:
+                with tiledb.open(element.uri, ctx=ctx) as A:
                     #print(A[:])
                     print("  ", element.uri, A.shape)
                     print(A.schema)
@@ -60,12 +61,13 @@ def show_single_cell_group(uri: str):
             # Not all groups have all four of obsm, obsp, varm, and varp.
             pass
 
-def show_tiledb_group_array_schemas(uri: str):
+
+def show_tiledb_group_array_schemas(uri: str, ctx: Optional[tiledb.Ctx] = None):
     """
     Recursively show array schemas within a TileDB Group. This function is not specific to
     single-cell matrix-API data.
     """
-    grp = tiledb.Group(uri, 'r')
+    grp = tiledb.Group(uri, mode='r', ctx=ctx)
     print()
     print('================================================================')
     print(uri)
@@ -79,7 +81,7 @@ def show_tiledb_group_array_schemas(uri: str):
             print()
             print('----------------------------------------------------------------')
             print(element.uri)
-            with tiledb.open(element.uri) as A:
+            with tiledb.open(element.uri, ctx=ctx) as A:
                 print(A.schema)
         else:
             print("Skipping element type", element.type)


### PR DESCRIPTION
Add config/context to python scgroup class to let the user set a TileDB configuration or TileDB context for opening/reading/writing the arrays and groups.