### PR TITLE
Improve default filters on X storage

### DIFF
--- a/apis/python/src/tiledbsc/scgroup.py
+++ b/apis/python/src/tiledbsc/scgroup.py
@@ -233,16 +233,17 @@ class SCGroup():
         obs_dim, var_dim = np.meshgrid(anndata.obs.index, anndata.var.index)
 
         dom = tiledb.Domain(
-            tiledb.Dim(name="obs_id", domain=(None, None), dtype="ascii"),
-            tiledb.Dim(name="var_id", domain=(None, None), dtype="ascii"),
+            tiledb.Dim(name="obs_id", domain=(None, None), dtype="ascii", filters=[tiledb.RleFilter()]),
+            tiledb.Dim(name="var_id", domain=(None, None), dtype="ascii", filters=[tiledb.ZstdFilter()]),
             ctx=self.ctx
         )
-        att = tiledb.Attr("data", ctx=self.ctx)
+        att = tiledb.Attr("data", dtype="float32", filters=[tiledb.ZstdFilter()], ctx=self.ctx)
         sch = tiledb.ArraySchema(
             domain=dom,
             attrs=(att,),
             sparse=True,
             allows_duplicates=True,
+            offsets_filters=[tiledb.DoubleDeltaFilter(), tiledb.BitWidthReductionFilter(), tiledb.ZstdFilter()],
             ctx=self.ctx
         )
         tiledb.Array.create(X_data_uri, sch, ctx=self.ctx)
@@ -281,17 +282,18 @@ class SCGroup():
             obs_dim, var_dim = np.meshgrid(anndata.raw.obs_names, anndata.raw.var_names)
 
             dom = tiledb.Domain(
-                tiledb.Dim(name="obs_id", domain=(None, None), dtype="ascii"),
-                tiledb.Dim(name="var_id", domain=(None, None), dtype="ascii"),
+                tiledb.Dim(name="obs_id", domain=(None, None), dtype="ascii", filters=[tiledb.RleFilter()]),
+                tiledb.Dim(name="var_id", domain=(None, None), dtype="ascii", filters=[tiledb.ZstdFilter()]),
                 ctx=self.ctx
             )
-            att = tiledb.Attr("raw", ctx=self.ctx)
+            att = tiledb.Attr("raw", dtype="float32", filters=[tiledb.ZstdFilter()], ctx=self.ctx)
 
             sch = tiledb.ArraySchema(
                 domain=dom,
                 attrs=(att,),
                 sparse=True,
                 allows_duplicates=True,
+                offsets_filters=[tiledb.DoubleDeltaFilter(), tiledb.BitWidthReductionFilter(), tiledb.ZstdFilter()],
                 ctx=self.ctx
             )
             tiledb.Array.create(X_raw_uri, sch, ctx=self.ctx)

--- a/apis/python/src/tiledbsc/scgroup.py
+++ b/apis/python/src/tiledbsc/scgroup.py
@@ -237,7 +237,12 @@ class SCGroup():
             tiledb.Dim(name="var_id", domain=(None, None), dtype="ascii", filters=[tiledb.ZstdFilter()]),
             ctx=self.ctx
         )
-        att = tiledb.Attr("data", dtype="float32", filters=[tiledb.ZstdFilter()], ctx=self.ctx)
+
+        # >>> anndata = ad.read_h5ad('anndata/pbmc3k_processed.h5ad')
+        # >>> anndata.X.dtype
+        dtype = 'float32'
+
+        att = tiledb.Attr("data", dtype=dtype, filters=[tiledb.ZstdFilter()], ctx=self.ctx)
         sch = tiledb.ArraySchema(
             domain=dom,
             attrs=(att,),
@@ -286,7 +291,12 @@ class SCGroup():
                 tiledb.Dim(name="var_id", domain=(None, None), dtype="ascii", filters=[tiledb.ZstdFilter()]),
                 ctx=self.ctx
             )
-            att = tiledb.Attr("raw", dtype="float32", filters=[tiledb.ZstdFilter()], ctx=self.ctx)
+
+            # >>> anndata = ad.read_h5ad('anndata/pbmc3k_processed.h5ad')
+            # >>> anndata.X.dtype
+            dtype = 'float32'
+
+            att = tiledb.Attr("raw", dtype=dtype, filters=[tiledb.ZstdFilter()], ctx=self.ctx)
 
             sch = tiledb.ArraySchema(
                 domain=dom,


### PR DESCRIPTION
One step for #17.

Note: this is distinct from https://github.com/single-cell-data/TileDB-SingleCell/issues/12.

Using this repo's `ingestor.py` on [anndata/pbmc3k_processed.h5ad](./anndata/pbmc3k_processed.h5ad):

```
$ du -hs tiledb-data/pbmc3k_processed.old/X/*
4.0K	tiledb-data/pbmc3k_processed.old/X/__group
  0B	tiledb-data/pbmc3k_processed.old/X/__meta
  0B	tiledb-data/pbmc3k_processed.old/X/__tiledb_group.tdb
 52M	tiledb-data/pbmc3k_processed.old/X/data
496M	tiledb-data/pbmc3k_processed.old/X/raw

$ du -hs tiledb-data/pbmc3k_processed/X/*
4.0K	tiledb-data/pbmc3k_processed/X/__group
  0B	tiledb-data/pbmc3k_processed/X/__meta
  0B	tiledb-data/pbmc3k_processed/X/__tiledb_group.tdb
 26M	tiledb-data/pbmc3k_processed/X/data
168M	tiledb-data/pbmc3k_processed/X/raw
```

Focus on particular files:

```
-rw-r--r--  1 johnkerl  staff    40M Apr 28 12:27 ./tiledb-data-old/pbmc3k_processed/X/raw/__fragments/__1651163257608_1651163257608_c112f18e07d244c0a06600d5f95c268e_12/d0.tdb
-rw-r--r--  1 johnkerl  staff   764K Apr 28 12:27 ./tiledb-data-old/pbmc3k_processed/X/raw/__fragments/__1651163257608_1651163257608_c112f18e07d244c0a06600d5f95c268e_12/d0_var.tdb
```

```
-rw-r--r--  1 johnkerl  staff    28K Apr 28 12:29 ./tiledb-data/pbmc3k_processed/X/raw/__fragments/__1651163343239_1651163343239_ecec68f643de4b7ab8647e5fb248deef_12/d0.tdb
-rw-r--r--  1 johnkerl  staff   264K Apr 28 12:29 ./tiledb-data/pbmc3k_processed/X/raw/__fragments/__1651163343239_1651163343239_ecec68f643de4b7ab8647e5fb248deef_12/d0_var.tdb
```

More files:

```
$ du -hs tiledb-data-old/*
778M	tiledb-data-old/bruce-559
256K	tiledb-data-old/bruce-nan
642M	tiledb-data-old/bruce-spatial
472K	tiledb-data-old/pbmc-small
656M	tiledb-data-old/pbmc3k_processed

$ du -hs tiledb-data/*
245M	tiledb-data/bruce-559
192K	tiledb-data/bruce-nan
640M	tiledb-data/bruce-spatial
296K	tiledb-data/pbmc-small
301M	tiledb-data/pbmc3k_processed
```