### PR TITLE
Refactor tests to compare against a reference object

### DIFF
--- a/apis/python/tests/test_tiledbsc.py
+++ b/apis/python/tests/test_tiledbsc.py
@@ -11,8 +11,6 @@ HERE = Path(__file__).parent
 
 @pytest.fixture
 def h5ad_file(request):
-    # Make sure this works regardless of from what directory level the `python -m pytest ...` is invoked
-    ourdir = request.fspath.dirname
     input_path = HERE.parent / "anndata/pbmc3k_processed.h5ad"
     return input_path
 

--- a/apis/python/tests/test_tiledbsc.py
+++ b/apis/python/tests/test_tiledbsc.py
@@ -5,12 +5,15 @@ import tiledbsc
 import pytest
 import tempfile
 import os
+from pathlib import Path
+
+HERE = Path(__file__).parent
 
 @pytest.fixture
 def h5ad_file(request):
     # Make sure this works regardless of from what directory level the `python -m pytest ...` is invoked
     ourdir = request.fspath.dirname
-    input_path = os.path.join(ourdir, '..', 'anndata', 'pbmc3k_processed.h5ad')
+    input_path = HERE.parent / "anndata/pbmc3k_processed.h5ad"
     return input_path
 
 @pytest.fixture

--- a/apis/python/tests/test_tiledbsc.py
+++ b/apis/python/tests/test_tiledbsc.py
@@ -6,18 +6,26 @@ import pytest
 import tempfile
 import os
 
-def test_import_anndata(request):
+@pytest.fixture
+def h5ad_file(request):
     # Make sure this works regardless of from what directory level the `python -m pytest ...` is invoked
     ourdir = request.fspath.dirname
+    input_path = os.path.join(ourdir, '..', 'anndata', 'pbmc3k_processed.h5ad')
+    return input_path
+
+@pytest.fixture
+def adata(h5ad_file):
+    return anndata.read_h5ad(h5ad_file)
+
+def test_import_anndata(h5ad_file):
 
     # Set up anndata input path and tiledb-group output path
-    input_path = os.path.join(ourdir, '..', 'anndata', 'pbmc3k_processed.h5ad')
     tempdir = tempfile.TemporaryDirectory()
     output_path = tempdir.name
 
     # Ingest
     scdataset = tiledbsc.SCGroup(output_path, verbose=True)
-    scdataset.from_h5ad(input_path)
+    scdataset.from_h5ad(h5ad_file)
 
     # Structure:
     #   X/data


### PR DESCRIPTION
A couple changes to our existing tests that will make it easier to swap reference objects and reuse code:

- use fixtures to generate file path for the test h5ad file and (separately) read it into memory as an `anndata` object
- use the [pathlib-based `HERE` convention](https://github.com/scverse/anndata/blob/a3af650d40fd804cd866d55a674a7eeaa20fdec0/anndata/tests/test_readwrite.py#L22) to conveniently reference test datasets
- update tests to compare directly against the test `anndata` object