### PR TITLE
Remove meshgrid deadcode

### DIFF
--- a/apis/python/src/tiledbsc/soma.py
+++ b/apis/python/src/tiledbsc/soma.py
@@ -253,9 +253,6 @@ class SOMA():
         if self.verbose:
             print(f"    START  WRITING {X_array_uri}")
 
-        # Here we do not use tiledb.from_numpy, so that we can have more control over the schema.
-        obs_dim, var_dim = np.meshgrid(obs_names, var_names)
-
         self.__create_coo_array(uri=X_array_uri, dim_labels=["obs_id", "var_id"], attr_name="value")
         self.__ingest_coo_data(X_array_uri, x, obs_names, var_names)
 


### PR DESCRIPTION
This takes a significant amount of time and space on larger data files.

It was used in previous revisions of the code this week but the need for it has been modded away.