### PR TITLE
Add row-wise chunked-COO ingest for CSR X/data and X/raw

### DIFF
--- a/apis/python/desc-ann-types.py
+++ b/apis/python/desc-ann-types.py
@@ -2,12 +2,7 @@
 
 # ================================================================
 # This is an anndata-describer that goes a bit beyond what h5ls does for us.
-#
-# See also:
-#
-# * `brew install hdf5`
-# * `h5ls -r anndata/pbmc3k_processed.h5ad`
-# * `h5ls -vr anndata/pbmc3k_processed.h5ad`
+# Similar to desc-ann.py but only shows essential data-type information.
 #
 # Please see comments in util_ann.py.
 # ================================================================
@@ -21,7 +16,7 @@ def main():
         sys.exit(1)
 
     for input_path in sys.argv[1:]:
-        tiledbsc.util_ann.describe_ann_file(input_path, False)
+        tiledbsc.util_ann.describe_ann_file(input_path, True)
 
 if __name__ == "__main__":
     main()

--- a/apis/python/ingestor.py
+++ b/apis/python/ingestor.py
@@ -40,4 +40,5 @@ if os.path.exists(output_path):
     shutil.rmtree(output_path) # Overwrite
 
 soma = tiledbsc.SOMA(output_path, verbose=True)
+# soma.set_write_X_chunked_if_csr(False)
 soma.from_h5ad(input_path)

--- a/apis/python/src/tiledbsc/soma.py
+++ b/apis/python/src/tiledbsc/soma.py
@@ -577,6 +577,10 @@ class SOMA():
 
         # Sort the row names so we can write chunks indexed by sorted string keys.  This will lead
         # to efficient TileDB fragments in the sparse array indexed by these string keys.
+        #
+        # Key note: only the _obs labels_ are being sorted, and along with them come permutation
+        # indices for accessing the CSR matrix via cursor-indirection -- e.g. csr[28] is accessed as
+        # with csr[permuation[28]] -- the CSR matrix itself isn't sorted in bulk.
         sorted_row_names, permutation = util.get_sort_and_permutation(list(row_names))
         # Using numpy we can index this with a list of indices, which a plain Python list doesn't support.
         sorted_row_names = np.asarray(sorted_row_names)

--- a/apis/python/src/tiledbsc/util.py
+++ b/apis/python/src/tiledbsc/util.py
@@ -1,3 +1,5 @@
+import numpy as np
+import scipy
 import time
 
 # ----------------------------------------------------------------
@@ -8,5 +10,53 @@ def get_start_stamp():
     """
     return time.time()
 
+# ----------------------------------------------------------------
 def format_elapsed(start_stamp, message: str):
+    """
+    Returns the message along with an elapsed-time indicator, with end time relative to start
+    start from get_start_stamp. Used for annotating elapsed time of a task.
+    """
     return "%s TIME %.3f" % (message, time.time() - start_stamp)
+
+# ----------------------------------------------------------------
+def find_csr_chunk_size(mat: scipy.sparse._csr.csr_matrix, permutation: list, start_row_index: int, goal_chunk_nnz: int):
+    """
+    Given a CSR matrix and a start row index, returns the number of rows with cumulative nnz as
+    desired. Context is chunked-COO ingest of larger CSR matrices: if mat is say 8000x9000 but
+    sparse, maybe we'll read rows 0:45 as one chunk and convert that to COO and ingest, then maybe
+    rows 46:78 as a second chunk and convert that to COO and ingest, and so on.
+    :param mat: The input CSR matrix.
+    :param permutation: Cursor-indices to access the CSR matrix, so it will be traversed in sort order.
+    :param start_row_index: the row index at which to start a chunk.
+    :param goal_chunk_nnz: Desired number of non-zero array entries for the chunk. 
+    """
+    chunk_size = 1
+    sum_nnz = 0
+    for row_index in range(start_row_index, mat.shape[0]):
+        sum_nnz += mat[permutation[row_index]].nnz
+        if sum_nnz > goal_chunk_nnz:
+            break
+        chunk_size += 1
+
+    return chunk_size
+
+# ----------------------------------------------------------------
+def get_sort_and_permutation(lst: list):
+    """
+    Sorts a list, returned the sorted list along with a permutation-index list which can be used for
+    cursored access to data which was indexed by the unsorted list. Nominally for chunking of CSR
+    matrices into TileDB which needs sorted string dimension-values for efficient fragmentation.
+    """
+    # Example input: x=['E','A','C','D','B']
+
+    # e.g. [('E', 0), ('A', 1), ('C', 2), ('D', 3), ('B', 4)]
+    lst_and_indices = [(e, i) for i,e in enumerate(lst)]
+
+    # e.g. [('A', 1), ('B', 4), ('C', 2), ('D', 3), ('E', 0)]
+    lst_and_indices.sort(key=lambda pair: pair[0])
+
+    # e.g. ['A' 'B' 'C' 'D' 'E']
+    # and  [1, 4, 2, 3, 0]
+    lst_sorted  = [e for e,i in lst_and_indices]
+    permutation = [i for e,i in lst_and_indices]
+    return (lst_sorted, permutation)

--- a/apis/python/src/tiledbsc/util.py
+++ b/apis/python/src/tiledbsc/util.py
@@ -1,0 +1,12 @@
+import time
+
+# ----------------------------------------------------------------
+def get_start_stamp():
+    """
+    Returns information about start time of an event. Nominally float seconds since the epoch,
+    but articulated here as being compatible with the format_elapsed function.
+    """
+    return time.time()
+
+def format_elapsed(start_stamp, message: str):
+    return "%s TIME %.3f" % (message, time.time() - start_stamp)

--- a/apis/python/src/tiledbsc/util_ann.py
+++ b/apis/python/src/tiledbsc/util_ann.py
@@ -1,11 +1,13 @@
 import sys, os
+import math
 import anndata as ad
 import pandas as pd
 import numpy as np
+import scipy
 import tiledb
 
 # ----------------------------------------------------------------
-def describe_ann_file(input_path: str):
+def describe_ann_file(input_path: str, types_only=False):
     """
     This is an anndata-describer that goes a bit beyond what h5ls does for us.
     In particular, it shows us that for one HDF5 file we have anndata.X being of type numpy.ndarray
@@ -16,22 +18,60 @@ def describe_ann_file(input_path: str):
     anndata.var_names_make_unique()
 
     print()
-    print("================================================================ {input_path}")
+    print(f"================================================================ {input_path}")
+    print("ANNDATA FILE TYPES:")
+
+    namewidth = 30
+
+    X = anndata.X
+    print("%-*s %s" % (namewidth, "X/data", type(X)))
+    m,n = X.shape
+    print("%-*s (%d, %d)" % (namewidth, "X/data shape", m, n))
+    if isinstance(X, scipy.sparse._csr.csr_matrix) or isinstance(X, scipy.sparse._csc.csc_matrix):
+        density = X.nnz / (m*n)
+        print("%-*s %.4f" % (namewidth, "X/data density", density))
+
+    has_raw = False
+    try: # not all groups have raw X
+        X = anndata.raw.X
+        has_raw = True
+    except:
+        pass
+
+    if has_raw:
+        X = anndata.raw.X
+        print("%-*s %s" % (namewidth, "X/raw", type(X)))
+        m,n = X.shape
+        print("%-*s (%d, %d)" % (namewidth, "X/raw shape", m, n))
+        if isinstance(X, scipy.sparse._csr.csr_matrix) or isinstance(X, scipy.sparse._csc.csc_matrix):
+            density = X.nnz / (m*n)
+            print("%-*s %.4f" % (namewidth, "X/raw density", density))
+
+    print("%-*s %s" % (namewidth, "obs", type(anndata.obs)))
+    print("%-*s %s" % (namewidth, "var", type(anndata.var)))
+
+    for k in anndata.obsm.keys():
+        print("%-*s %s" % (namewidth, "obsm/"+k, type(anndata.obsm[k])))
+
+    for k in anndata.varm.keys():
+        print("%-*s %s" % (namewidth, "varm/"+k, type(anndata.varm[k])))
+
+    for k in anndata.obsp.keys():
+        print("%-*s %s" % (namewidth, "obsp/"+k, type(anndata.obsp[k])))
+
+    for k in anndata.varp.keys():
+        print("%-*s %s" % (namewidth, "varp/"+k, type(anndata.varp[k])))
+
+    if types_only:
+        return
+
+    print()
     print("ANNDATA SUMMARY:")
     print(anndata)
 
-    print("X IS A   ", type(anndata.X))
-    print("  X SHAPE  ", anndata.X.shape)
-    print("  OBS  LEN ", len(anndata.obs))
-    print("  VAR  LEN ", len(anndata.var))
-
-    try: # not all groups have raw X
-        print("RAW X IS A   ", type(anndata.raw.X))
-        print("  X SHAPE  ", anndata.raw.X.shape)
-        print("  OBS  LEN ", len(anndata.raw.X.obs_names))
-        print("  VAR  LEN ", len(anndata.raw.X.var_names))
-    except:
-        pass
+    print("X SHAPE  ", anndata.X.shape)
+    print("OBS  LEN ", len(anndata.obs))
+    print("VAR  LEN ", len(anndata.var))
 
     print('OBS IS A', type(anndata.obs))
     for name in anndata.obs.keys():
@@ -40,21 +80,20 @@ def describe_ann_file(input_path: str):
     for name in anndata.var.keys():
         print("  ", name, anndata.var[name].dtype)
 
+    try: # not all groups have raw X
+        print("RAW X SHAPE  ", anndata.raw.X.shape)
+        print(" RAW OBS  LEN ", len(anndata.raw.X.obs_names))
+        print("RAW VAR  LEN ", len(anndata.raw.X.var_names))
+    except:
+        pass
+
+    print("OBS  KEYS", list(anndata.obs.keys()))
+    print("VAR  KEYS", list(anndata.var.keys()))
+
     print("OBSM KEYS", list(anndata.obsm.keys()))
-    for k in anndata.obsm.keys():
-        print('  OBSM', k, 'IS A', type(anndata.obsm[k]))
-
     print("VARM KEYS", list(anndata.varm.keys()))
-    for k in anndata.varm.keys():
-        print('  VARM', k, 'IS A', type(anndata.varm[k]))
-
     print("OBSP KEYS", list(anndata.obsp.keys()))
-    for k in anndata.obsp.keys():
-        print('  OBSP', k, 'IS A', type(anndata.obsp[k]))
-
     print("VARP KEYS", list(anndata.varp.keys()))
-    for k in anndata.varp.keys():
-        print('  VARP', k, type(anndata.varp[k]))
 
     # Defer unstructured data for now:
     # show_uns_types(anndata.uns)

--- a/apis/python/src/tiledbsc/util_ann.py
+++ b/apis/python/src/tiledbsc/util_ann.py
@@ -1,32 +1,6 @@
-import sys, os
-import math
 import anndata as ad
-import pandas as pd
 import numpy as np
 import scipy
-import tiledb
-
-# ----------------------------------------------------------------
-def find_csr_chunk_size(mat: scipy.sparse._csr.csr_matrix, start_row_index: int, capacity: int):
-    """
-    Given a CSR matrix and a start row index, returns the number of rows with cumulative nnz
-    targeted to be around the capacity argument. Context is chunked-COO ingest of larger CSR
-    matrices: if mat is say 8000x9000 but sparse, maybe we'll read rows 0:45 as one chunk and
-    convert that to COO and ingest, then maybe rows 46:78 as a second chunk and convert that to COO
-    and ingest, and so on.
-    :param mat: The input CSR matrix.
-    :param start_row_index: the row index at which to start a chunk.
-    :param capacity: TileDB array-schema capacity parameter.
-    """
-    chunk_size = 1
-    sum_nnz = 0
-    for row_index in range(start_row_index, mat.shape[0]):
-        sum_nnz += mat[row_index].nnz
-        if sum_nnz > capacity:
-            break
-        chunk_size += 1
-
-    return chunk_size
 
 # ----------------------------------------------------------------
 def describe_ann_file(input_path: str, types_only=False):


### PR DESCRIPTION
# Summary

Context: #37 

For CSR X data/raw matrices (CSC flagged as a to-do), ingest the CSR to COO not all at once, but rather, a few rows at a time, converting each chunk to COO and doing a TileDB write on that chunk.

For CSR matrices which can be whole-COO'ed into RAM, this runs no faster than before; for those which are too large to be whole-COO'ed into RAM, this makes ingestion possible.

Resulting storage space can be slightly larger than it otherwise would be: each TileDB write forces a new fragment, so we should carefully consider the chunk-sizing decision. As of this writing, this is done by matching chunk nnz to a fixed parameter -- which we can make configurable on #27.

PR-reviewer alert: there's some timing-related/transparency stuff on this PR, so https://github.com/single-cell-data/TileDB-SingleCell/pull/44/commits may be helpful.

# Output and timing

```
$ ./ingestor.py ~/scdata/anndata/bruce-559.h5ad tiledbdata/bruce-559-ordered
START  SOMA.from_h5ad /Users/johnkerl/scdata/anndata/bruce-559.h5ad -> tiledb-data/bruce-559-ordered
  START  READING /Users/johnkerl/scdata/anndata/bruce-559.h5ad
  FINISH READING /Users/johnkerl/scdata/anndata/bruce-559.h5ad TIME 0.379
  START  DECATEGORICALIZING
  FINISH DECATEGORICALIZING TIME 0.015
  START  WRITING tiledb-data/bruce-559-ordered
    START  WRITING tiledb-data/bruce-559-ordered/X/data from <class 'scipy.sparse._csr.csr_matrix'>
      START  __ingest_coo_data_rows_chunked
        START  chunk rows 0..2541 of 2541, obs_ids X1000010011.A01..X1000102804.H9, nnz=8245406, 100.000%
        FINISH chunk TIME 59.973
      FINISH __ingest_coo_data_rows_chunked TIME 60.504
    FINISH WRITING tiledb-data/bruce-559-ordered/X/data TIME 60.563
    START  WRITING tiledb-data/bruce-559-ordered/obs
    FINISH WRITING tiledb-data/bruce-559-ordered/obs TIME 0.128
    START  WRITING tiledb-data/bruce-559-ordered/var
    FINISH WRITING tiledb-data/bruce-559-ordered/var TIME 0.043
    START  WRITING tiledb-data/bruce-559-ordered/obsm/X_tsne
    Annotation matrix obsm/X_tsne has shape (2541, 2)
    FINISH WRITING tiledb-data/bruce-559-ordered/obsm/X_tsne TIME 0.020
  FINISH WRITING tiledb-data/bruce-559-ordered TIME 60.764
FINISH SOMA.from_h5ad /Users/johnkerl/scdata/anndata/bruce-559.h5ad -> tiledb-data/bruce-559-ordered TIME 61.160
```

# Schema and storage

```
>>> A = tiledb.open('tiledb-data/bruce-559-ordered/X/data')
>>> A.schema
ArraySchema(
  domain=Domain(*[
    Dim(name='obs_id', domain=(None, None), tile=None, dtype='|S0', var=True, filters=FilterList([RleFilter(), ])),
    Dim(name='var_id', domain=(None, None), tile=None, dtype='|S0', var=True, filters=FilterList([ZstdFilter(level=22), ])),
  ]),
  attrs=[
    Attr(name='value', dtype='float32', var=False, nullable=False, filters=FilterList([ZstdFilter(level=-1), ])),
  ],
  cell_order='row-major',
  tile_order='col-major',
  capacity=100000,
  sparse=True,
  allows_duplicates=True,
)
```

```
$ du -hs ~/scdata/anndata/bruce-559.h5ad
 32M	/Users/johnkerl/scdata/anndata/bruce-559.h5ad
$ du -hs ./tiledb-data/bruce-559-ordered
 28M	./tiledb-data/bruce-559-ordered
```

```
$ du -hs tiledb-data/bruce-559-ordered/X/data/__fragments/* | cat -n
     1	 27M	tiledb-data/bruce-559-ordered/X/data/__fragments/__1651411469736_1651411469736_83417345b25843abba3763c43c7bdfda_12
```

# Sample query

First, inspect the dataframe to find some expected values from a query to be performed:

```
>>> A = tiledb.open('tiledb-data/bruce-559-ordered/X/data')
>>> df = A[:]

>>> len(df['value'])
8245406
>>> len(df['obs_id'])
8245406
>>> len(df['var_id'])
8245406

>>> df['obs_id'][12345]
b'X1000010011.A06'
>>> df['var_id'][12345]
b'ENSG00000072042'
>>> df['value'][12345]
150.0
```

Second, perform the query and validate the results are as expected:

```
>>> q['X1000010011.A06', 'ENSG00000072042']
OrderedDict([('value', array([150.], dtype=float32)), ('obs_id', array([b'X1000010011.A06'], dtype=object)), ('var_id', array([b'ENSG00000072042'], dtype=object))])
```

Comparison to data written without the [ordering commit](https://github.com/single-cell-data/TileDB-SingleCell/pull/44/commits/b058c1fadd2770a66b64fe6482b726bdfd86a24e):

```
import tiledb

array_uris = ['tiledb-data/bruce-559-unordered/X/data', 'tiledb-data/bruce-559-ordered/X/data']
for array_uri in array_uris:
    print()
    print(array_uri)
    with tiledb.open(array_uri) as A:
        df = A[:]
        q = A.query(attrs=('value',))
        for i in [12345, 567, 7654321, 999999]:
            print(q[df['obs_id'][i], df['var_id'][i]])
```

with output

```
tiledb-data/bruce-559-unordered/X/data
OrderedDict([('value', array([150.], dtype=float32)), ('obs_id', array([b'X1000010011.A06'], dtype=object)), ('var_id', array([b'ENSG00000072042'], dtype=object))])
OrderedDict([('value', array([1.], dtype=float32)), ('obs_id', array([b'X1000010011.A01'], dtype=object)), ('var_id', array([b'ENSG00000103507'], dtype=object))])
OrderedDict([('value', array([5.], dtype=float32)), ('obs_id', array([b'X1000102802.C12'], dtype=object)), ('var_id', array([b'ENSG00000175220'], dtype=object))])
OrderedDict([('value', array([84.], dtype=float32)), ('obs_id', array([b'X1000010014.B07'], dtype=object)), ('var_id', array([b'ENSG00000173085'], dtype=object))])

tiledb-data/bruce-559-ordered/X/data
OrderedDict([('value', array([150.], dtype=float32)), ('obs_id', array([b'X1000010011.A06'], dtype=object)), ('var_id', array([b'ENSG00000072042'], dtype=object))])
OrderedDict([('value', array([1.], dtype=float32)), ('obs_id', array([b'X1000010011.A01'], dtype=object)), ('var_id', array([b'ENSG00000103507'], dtype=object))])
OrderedDict([('value', array([5.], dtype=float32)), ('obs_id', array([b'X1000102802.C12'], dtype=object)), ('var_id', array([b'ENSG00000175220'], dtype=object))])
OrderedDict([('value', array([84.], dtype=float32)), ('obs_id', array([b'X1000010014.B07'], dtype=object)), ('var_id', array([b'ENSG00000173085'], dtype=object))])
```

# Further sizes

```
$ ls -lh ~/scdata/anndata-aux/autoimmunity-pbmcs.h5ad
-rw-r--r--@ 1 johnkerl  staff   686M Apr 25 22:50 /Users/johnkerl/scdata/anndata-aux/autoimmunity-pbmcs.h5ad

$ du -hs tiledb-data/autoimmunity-pbmcs/
688M	tiledb-data/autoimmunity-pbmcs/

$ du -hs tiledb-data/autoimmunity-pbmcs/X/data/__fragments/*
 23M	tiledb-data/autoimmunity-pbmcs/X/data/__fragments/__1651412019373_1651412019373_33edcc8f145547cb97032377b8937d89_12
 23M	tiledb-data/autoimmunity-pbmcs/X/data/__fragments/__1651412086793_1651412086793_6435d23a5b3340cc94d6b26f0d481ce7_12
 24M	tiledb-data/autoimmunity-pbmcs/X/data/__fragments/__1651412164586_1651412164586_5c068a1b4c034ebd9e0f39a242b56cf8_12
 24M	tiledb-data/autoimmunity-pbmcs/X/data/__fragments/__1651412237724_1651412237724_3fd018298add4cad9396be78a11123a3_12
 24M	tiledb-data/autoimmunity-pbmcs/X/data/__fragments/__1651412311537_1651412311537_8fde80fb76274af89777a5c0fbaab0e0_12
 24M	tiledb-data/autoimmunity-pbmcs/X/data/__fragments/__1651412378137_1651412378137_3ce472509a2347baa22d370a4eedeaf2_12
 24M	tiledb-data/autoimmunity-pbmcs/X/data/__fragments/__1651412443853_1651412443853_d06f70c0be9147148cfdd0c2f3af7190_12
 24M	tiledb-data/autoimmunity-pbmcs/X/data/__fragments/__1651412508884_1651412508884_f8cbf3db166045e4b1cf161bf4238f28_12
 24M	tiledb-data/autoimmunity-pbmcs/X/data/__fragments/__1651412572798_1651412572798_1cd80e4f3c5443e8ab947d5de871be11_12
 24M	tiledb-data/autoimmunity-pbmcs/X/data/__fragments/__1651412636128_1651412636128_386bf0f659e24d079db5a45342bdcb9f_12
 24M	tiledb-data/autoimmunity-pbmcs/X/data/__fragments/__1651412697714_1651412697714_a64b40f058ef42a59f032aac16a74712_12
 24M	tiledb-data/autoimmunity-pbmcs/X/data/__fragments/__1651412769882_1651412769882_10e6c9f3d43b43afbf3433a9fa277c9a_12
 24M	tiledb-data/autoimmunity-pbmcs/X/data/__fragments/__1651412837031_1651412837031_c6dfb7f38ed34b6e905a103f1203d453_12
 24M	tiledb-data/autoimmunity-pbmcs/X/data/__fragments/__1651412897378_1651412897378_c79d0cd6e91e45acb6716dde42ca951c_12
4.0M	tiledb-data/autoimmunity-pbmcs/X/data/__fragments/__1651412953317_1651412953317_84c456b023b24d3884e32607a6c6fc09_12
```

I currently have a 5.6GB `.h5ad` file ingesting on my laptop, not complete yet, but running with bounded memory as shown by `htop`.