### PR TITLE
Show column dtypes for obs and var

### DIFF
--- a/apis/python/src/tiledbsc/util_ann.py
+++ b/apis/python/src/tiledbsc/util_ann.py
@@ -34,9 +34,11 @@ def describe_ann_file(input_path: str):
         pass
 
     print('OBS IS A', type(anndata.obs))
-    print("  OBS  KEYS", list(anndata.obs.keys()))
+    for name in anndata.obs.keys():
+        print("  ", name, anndata.obs[name].dtype)
     print('VAR IS A', type(anndata.var))
-    print("  VAR  KEYS", list(anndata.var.keys()))
+    for name in anndata.var.keys():
+        print("  ", name, anndata.var[name].dtype)
 
     print("OBSM KEYS", list(anndata.obsm.keys()))
     for k in anndata.obsm.keys():


### PR DESCRIPTION
Several of the type-diversity issues at
https://github.com/single-cell-data/TileDB-SingleCell/issues?q=is%3Aissue+is%3Aopen+label%3Aedge-case
involve various dtypes for `obs` and `var` in anndata files.

Here we surface those readily at a glance. (I use the `desc-ann.py` script routinely as a keystroke-saver/work-accelerator for this project.)

```
$ ./desc-ann.py ~/scdata/anndata/bruce-spatial.h5ad
================================================================ {input_path}
ANNDATA SUMMARY:
AnnData object with n_obs × n_vars = 6471 × 33
    obs: 'CellType', 'Region', 'Valid', 'n_genes_by_counts', 'log1p_n_genes_by_counts', 'total_counts', 'log1p_total_counts', 'leiden', 'louvain'
    var: 'Fluorophore', 'Hybridization', 'n_cells_by_counts', 'mean_counts', 'log1p_mean_counts', 'pct_dropout_by_counts', 'total_counts', 'log1p_total_counts'
    uns: 'leiden', 'louvain', 'neighbors'
    obsm: 'X_spatial', 'X_tsne', 'X_umap'
    obsp: 'distances', 'connectivities'
X IS A    <class 'scipy.sparse._csr.csr_matrix'>
  X SHAPE   (6471, 33)
  OBS  LEN  6471
  VAR  LEN  33
OBS IS A <class 'pandas.core.frame.DataFrame'>
   CellType category                                   | NEW ON THIS PR
   Region category                                     | ...
   Valid category                                      | ...
   n_genes_by_counts int32                             | ...
   log1p_n_genes_by_counts float64                     | ...
   total_counts float32                                | ...
   log1p_total_counts float32                          | ...
   leiden category                                     | ...
   louvain category                                    | NEW ON THIS PR
VAR IS A <class 'pandas.core.frame.DataFrame'>
   Fluorophore category                                | NEW ON THIS PR
   Hybridization int64                                 | ...
   n_cells_by_counts int64                             | ...
   mean_counts float32                                 | ...
   log1p_mean_counts float32                           | ...
   pct_dropout_by_counts float64                       | ...
   total_counts float32                                | ...
   log1p_total_counts float32                          | NEW ON THIS PR
OBSM KEYS ['X_spatial', 'X_tsne', 'X_umap']
  OBSM X_spatial IS A <class 'numpy.ndarray'>
  OBSM X_tsne IS A <class 'numpy.ndarray'>
  OBSM X_umap IS A <class 'numpy.ndarray'>
VARM KEYS []
OBSP KEYS ['distances', 'connectivities']
  OBSP distances IS A <class 'scipy.sparse._csr.csr_matrix'>
  OBSP connectivities IS A <class 'scipy.sparse._csr.csr_matrix'>
VARP KEYS []
```