### PR TITLE
Array fragment printer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,11 +38,11 @@ examples/cmake_project/build
 **/site-packages/*
 **/bin/*
 **/share/*
-*.egg-info
+**/build/*
 **/__pycache__
 *.so
 *.dylib
 
-### Gradle ###
-.gradle
-/build/
+# Python distribution / packaging
+.eggs
+*.egg-info

--- a/apis/python/desc-array-fragments.py
+++ b/apis/python/desc-array-fragments.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+
+# ================================================================
+# Prints a table providing details about the fragments of an array.
+# ================================================================
+
+import argparse
+import tiledb
+import pandas
+
+def list_fragments(array_uri: str):
+    print(f"Listing fragments for array: '{array_uri}'")
+    vfs = tiledb.VFS()
+
+    fragments = []
+    fi = tiledb.fragment.FragmentInfoList(array_uri=array_uri)
+
+    for f in fi:
+        f_dict = {
+            "array_schema_name": f.array_schema_name,
+            "num": f.num,
+            "cell_num": f.cell_num,
+            "size": vfs.dir_size(f.uri)
+        }
+
+        # parse nonempty domains into separate columns
+        for d in range(len(f.nonempty_domain)):
+            f_dict[f"d{d}"] = f.nonempty_domain[d]
+
+        fragments.append(f_dict)
+
+    frags_df = pandas.DataFrame(fragments)
+    print(frags_df)
+
+
+def main():
+    p = argparse.ArgumentParser()
+    p.add_argument(
+        "array_uri",
+        type=str,
+        help="URI of the array to list fragments for",
+    )
+    args = p.parse_args()
+    list_fragments(args.array_uri)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Adds a small utility to print a table containing details for each fragment in an array, including their size and non-empty domains for each dim.

Example:

```
> ./desc-array-fragments.py dev/arrays/bruce-559-ordered/X/data

Listing fragments for array: 'dev/arrays/bruce-559-ordered/X/data'
                                   array_schema_name  num  cell_num     size                                  d0                             d1
0  __1651499718503_1651499718503_eb799bf7b8354d02...    0   1001152  3381993  (X1000010011.A01, X1000010014.B07)  (ENSG00000000003, ERCC-00171)
1  __1651499718503_1651499718503_eb799bf7b8354d02...    1   1002502  3427963  (X1000010014.B08, X1000010016.D03)  (ENSG00000000003, ERCC-00171)
2  __1651499718503_1651499718503_eb799bf7b8354d02...    2   1001036  3523571   (X1000010016.D04, X1000101204.C3)  (ENSG00000000003, ERCC-00171)
3  __1651499718503_1651499718503_eb799bf7b8354d02...    3   1002413  3476786    (X1000101204.C6, X1000101501.C7)  (ENSG00000000003, ERCC-00171)
4  __1651499718503_1651499718503_eb799bf7b8354d02...    4   1003110  3721794    (X1000101501.C9, X1000101606.D6)  (ENSG00000000003, ERCC-00171)
5  __1651499718503_1651499718503_eb799bf7b8354d02...    5   1004803  3526841    (X1000101606.D8, X1000101704.A1)  (ENSG00000000003, ERCC-00171)
6  __1651499718503_1651499718503_eb799bf7b8354d02...    6   1001529  3558243   (X1000101704.A10, X1000102503.C7)  (ENSG00000000003, ERCC-00171)
7  __1651499718503_1651499718503_eb799bf7b8354d02...    7   1001500  3464973   (X1000102503.D12, X1000102804.A7)  (ENSG00000000003, ERCC-00171)
8  __1651499718503_1651499718503_eb799bf7b8354d02...    8    227361   762764    (X1000102804.A8, X1000102804.H9)  (ENSG00000000003, ERCC-00171)
```