### PR TITLE
Change group structure to have raw/X, raw/var, raw/varm

### DIFF
--- a/apis/python/README.md
+++ b/apis/python/README.md
@@ -58,6 +58,50 @@ Please see [https://github.com/single-cell-data/TileDB-SingleCell/issues](https:
 
 # Details
 
+## TileDB group structure
+
+```
+soma: group
+|
++-- X: group
+|   +-- data: array
+|
++-- obs: array
+|
++-- var: array
+|
++-- obsm: group
+|   +-- omfoo: array
+|   +-- ombar: array
+|
++-- varm: group
+|   +-- vmfoo: array
+|   +-- vmbar: array
+|
++-- obsp: group
+|   +-- opfoo: array
+|   +-- opbar: array
+|
++-- varp: group
+|   +-- vpfoo: array
+|   +-- vpbar: array
+|
++-- raw: group
+    |
+    +-- X: group
+    |   +-- data: array
+    |
+    +-- var: array
+    |
+    +-- varm: group
+    |   +-- vmfoo: array
+    |   +-- vmbar: array
+    |
+    +-- varp: group
+        +-- vpfoo: array
+        +-- vpbar: array
+```
+
 ## Expected input format
 
 `./desc-ann.py ./anndata/pbmc3k_processed.h5ad`

--- a/apis/python/src/tiledbsc/soma.py
+++ b/apis/python/src/tiledbsc/soma.py
@@ -317,7 +317,9 @@ class SOMA():
     # ----------------------------------------------------------------
     def write_X_group(self, X_group_uri: str, anndata: ad.AnnData):
         """
-        Populates the X/ subgroup for a SOMA object.
+        Populates the X/ or raw/X subgroup for a SOMA object.
+
+        :param X_group_uri: URI where the group is to be written.
         """
         tiledb.group_create(X_group_uri, ctx=self.ctx)
         X_group = tiledb.Group(X_group_uri, mode="w", ctx=self.ctx)
@@ -332,9 +334,11 @@ class SOMA():
     def write_X_array(self, X_array_uri, X, obs_names, var_names):
         """
         Populates the X/data or X/raw array.
-        :param X_array_uri: URI where the array is to be written
-        :param X: is anndata.X or anndata.raw.X
-        :param obs_names: and var_names are the names for the axes
+
+        :param X_array_uri: URI where the array is to be written.
+        :param X: is anndata.X or anndata.raw.X.
+        :param obs_names: names for the first/row dimension.
+        :param var_names: names for the second/column dimension.
         """
         if self.verbose:
             s = util.get_start_stamp()
@@ -355,6 +359,11 @@ class SOMA():
     def write_obs_or_var(self, obs_or_var_uri: str, obs_or_var_data, obs_or_var_name: str, extent: int):
         """
         Populates the obs/ or var/ subgroup for a SOMA object.
+
+        :param obs_or_var_uri: URI where the array is to be written.
+        :param obs_or_var_data: anndata.obs, anndata.var, anndata.raw.var.
+        :param obs_or_var_name: 'obs' or 'var'.
+        :param extent: TileDB extent parameter for the array schema.
         """
 
         offsets_filters = tiledb.FilterList(
@@ -411,6 +420,12 @@ class SOMA():
 
     # ----------------------------------------------------------------
     def write_raw_group(self, raw_group_uri: str, raw: ad.Raw):
+        """
+        Populates the raw group for the soma object.
+
+        :param raw_group_uri: URI where the group is to be written.
+        :param raw: anndata.raw.
+        """
 
         if self.verbose:
             s = util.get_start_stamp()
@@ -431,10 +446,12 @@ class SOMA():
         """
         Populates the obsm/ or varm/ subgroup for a SOMA object, then writes all the components
         arrays under that group.
-        :param annotation_matrices: anndata.obsm or anndata.varm
+
+        :param subgroup_uri: URI where the subgroup is to be written.
+        :param annotation_matrices: anndata.obsm, anndata.varm, or anndata.raw.varm.
         :param name: 'obsm' or 'varm'
         :param dim_name: 'obs_id' or 'var_id'
-        :param dim_values: anndata.obs_names or anndata.var_names
+        :param dim_values: anndata.obs_names, anndata.var_names, or anndata.raw.var_names.
         """
         assert name in ["obsm", "varm"]
 
@@ -470,10 +487,12 @@ class SOMA():
         """
         Populates the obsp/ or varp/ subgroup for a SOMA object, then writes all the components
         arrays under that group.
-        :param annotation_matrices: anndata.obsp or anndata.varp
-        :param name: 'obsp' or 'varp'
-        :param dim_name: 'obs_id' or 'var_id'
-        :param dim_values: anndata.obs_names or anndata.var_names
+
+        :param subgroup_uri: URI where the array is to be written.
+        :param annotation_matrices: anndata.obsp or anndata.varp.
+        :param name: 'obsp' or 'varp'.
+        :param dim_name: 'obs_id' or 'var_id'.
+        :param dim_values: anndata.obs_names or anndata.var_names.
         """
         assert name in ["obsp", "varp"]
 
@@ -503,7 +522,7 @@ class SOMA():
     # ----------------------------------------------------------------
     def __create_annot_matrix(self, uri: str, mat, mat_name: str, dim_name: str, attr_names):
         """
-        Create a TileDB 1D sparse array with string dimension and multiple attributes
+        Create a TileDB 1D sparse array with string dimension and multiple attributes.
 
         :param uri: URI of the array to be created
         :param mat: e.g. anndata.obsm['X_pca'] -- nominally a numpy.ndarray
@@ -552,6 +571,7 @@ class SOMA():
     def __ingest_annot_matrix(self, uri: str, mat, dim_values, col_names):
         """
         Convert ndarray/(csr|csc)matrix to a dataframe and ingest into TileDB.
+
         :param uri: TileDB URI of the array to be written.
         :param mat: Matrix-like object coercible to a pandas dataframe.
         :param dim_values: barcode/gene IDs from anndata.obs_names or anndata.var_names
@@ -801,6 +821,7 @@ class SOMA():
         """
         Reads the TileDB obs or var array and returns a type of pandas dataframe
         and dimension values.
+
         :param array_name: 'obs' or 'var'
         :param index_name: 'obs_id' or 'var_id'
         """
@@ -825,6 +846,7 @@ class SOMA():
     def outgest_X(self, obs_labels, var_labels):
         """
         Given a TileDB soma group, returns a scipy.sparse.csr_matrix with the X data.
+
         :param obs_labels: from the obs array. Note that TileDB will have sorted these.
         :param var_labels: from the var array. Note that TileDB will have sorted these.
         """
@@ -883,6 +905,7 @@ class SOMA():
         """
         Reads the TileDB obsm or varm group and returns a dict from array name to array.
         These arrays are in numpy.ndarray format.
+
         :param soma_path: Path to the soma group.
         :param group_name: "obsm" or "varm".
         :param index_name: "obs_id" or "var_id".
@@ -931,6 +954,7 @@ class SOMA():
         """
         Reads the TileDB obsp or varp group and returns a dict from array name to array.
         These arrays are in scipy.csr format.
+
         :param soma_path: Path to the soma group.
         :param group_name: "obsp" or "varp".
         """

--- a/apis/python/src/tiledbsc/util.py
+++ b/apis/python/src/tiledbsc/util.py
@@ -1,5 +1,6 @@
 import numpy as np
 import scipy
+import pandas as pd
 import time
 
 # ----------------------------------------------------------------
@@ -60,3 +61,19 @@ def get_sort_and_permutation(lst: list):
     lst_sorted  = [e for e,i in lst_and_indices]
     permutation = [i for e,i in lst_and_indices]
     return (lst_sorted, permutation)
+
+# ----------------------------------------------------------------
+def decategoricalize_array(x):
+    """
+    Converts datatypes unrepresentable by TileDB into datatypes it can represent.
+    Categorical strings -> string; bool -> uint8.
+    See also https://docs.scipy.org/doc/numpy-1.10.1/reference/arrays.dtypes.html
+    """
+    if isinstance(x.dtype, pd.CategoricalDtype):
+        return x.astype('O')
+    elif x.dtype == 'bool':
+        return x.astype('uint8')
+    elif x.dtype == np.float16:
+        return x.astype(np.float16)
+    else:
+        return x

--- a/apis/python/tests/test_tiledbsc.py
+++ b/apis/python/tests/test_tiledbsc.py
@@ -34,7 +34,6 @@ def test_import_anndata(adata):
 
     # Structure:
     #   X/data
-    #   X/raw
     #   obs
     #   var
     #   obsm/X_pca
@@ -44,6 +43,9 @@ def test_import_anndata(adata):
     #   varm/PCs
     #   obsp/distances
     #   obsp/connectivities
+    #   raw/X/data
+    #   raw/var
+    #   raw/varm/PCs
 
     # Check X/data (dense)
     with tiledb.open(os.path.join(output_path, 'X', 'data')) as A:
@@ -53,7 +55,7 @@ def test_import_anndata(adata):
         assert A.ndim == 2
 
     # Check X/raw (sparse)
-    with tiledb.open(os.path.join(output_path, 'X', 'raw')) as A:
+    with tiledb.open(os.path.join(output_path, 'raw', 'X', 'data')) as A:
         df = A.df[:]
         assert df.columns.to_list() == ['obs_id', 'var_id', 'value']
         # verify sparsity of raw data


### PR DESCRIPTION
Context: https://github.com/single-cell-data/TileDB-SingleCell/issues/15

Reviewer advice: this is a cross-cutting PR; going through
https://github.com/single-cell-data/TileDB-SingleCell/pull/64/commits
may be helpful ... 🙏 

Old:

```
 GROUP
|-- X GROUP
|------ data ARRAY
|------ raw ARRAY
|-- obs ARRAY
|-- var ARRAY
|-- obsm GROUP
|------ foo ARRAY
|-- varm GROUP
|------ bar ARRAY
```

New:

```
 GROUP
|-- X GROUP
|------ data ARRAY
|-- obs ARRAY
|-- var ARRAY
|-- obsm GROUP
|------ X_tsne ARRAY
|------ X_pca ARRAY
|-- varm GROUP
|------ PCs ARRAY
|-- obsp GROUP
|------ distances ARRAY
|-- raw GROUP
|------ X GROUP
|---------- data ARRAY
|------ var ARRAY
```
Sample ingest:

```
$ ./ingestor.py anndata/pbmc3k_processed.h5ad
START  SOMA.from_h5ad anndata/pbmc3k_processed.h5ad -> tiledb-data/pbmc3k_processed
  START  READING anndata/pbmc3k_processed.h5ad
/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/anndata/compat/__init__.py:232: FutureWarning: Moving element from .uns['neighbors']['distances'] to .obsp['distances'].

This is where adjacency matrices should go now.
  warn(
/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/anndata/compat/__init__.py:232: FutureWarning: Moving element from .uns['neighbors']['connectivities'] to .obsp['connectivities'].

This is where adjacency matrices should go now.
  warn(
  FINISH READING anndata/pbmc3k_processed.h5ad TIME 0.262
  START  DECATEGORICALIZING
  FINISH DECATEGORICALIZING TIME 0.002
  START  WRITING tiledb-data/pbmc3k_processed
    START  WRITING tiledb-data/pbmc3k_processed/X/data from <class 'numpy.ndarray'>
    FINISH WRITING tiledb-data/pbmc3k_processed/X/data TIME 3.225
    START  WRITING tiledb-data/pbmc3k_processed/obs
    FINISH WRITING tiledb-data/pbmc3k_processed/obs TIME 0.059
    START  WRITING tiledb-data/pbmc3k_processed/var
    FINISH WRITING tiledb-data/pbmc3k_processed/var TIME 0.024
    START  WRITING tiledb-data/pbmc3k_processed/obsm/X_pca
    Annotation matrix obsm/X_pca has shape (2638, 50)
    FINISH WRITING tiledb-data/pbmc3k_processed/obsm/X_pca TIME 0.146
    START  WRITING tiledb-data/pbmc3k_processed/obsm/X_tsne
    Annotation matrix obsm/X_tsne has shape (2638, 2)
    FINISH WRITING tiledb-data/pbmc3k_processed/obsm/X_tsne TIME 0.036
    START  WRITING tiledb-data/pbmc3k_processed/obsm/X_umap
    Annotation matrix obsm/X_umap has shape (2638, 2)
    FINISH WRITING tiledb-data/pbmc3k_processed/obsm/X_umap TIME 0.030
    START  WRITING tiledb-data/pbmc3k_processed/obsm/X_draw_graph_fr
    Annotation matrix obsm/X_draw_graph_fr has shape (2638, 2)
    FINISH WRITING tiledb-data/pbmc3k_processed/obsm/X_draw_graph_fr TIME 0.028
    START  WRITING tiledb-data/pbmc3k_processed/varm/PCs
    Annotation matrix varm/PCs has shape (1838, 50)
    FINISH WRITING tiledb-data/pbmc3k_processed/varm/PCs TIME 0.090
    START  WRITING tiledb-data/pbmc3k_processed/obsp/distances
    Annotation-pairwise matrix obsp/distances has shape (2638, 2638)
    FINISH WRITING tiledb-data/pbmc3k_processed/obsp/distances TIME 0.069
    START  WRITING tiledb-data/pbmc3k_processed/obsp/connectivities
    Annotation-pairwise matrix obsp/connectivities has shape (2638, 2638)
    FINISH WRITING tiledb-data/pbmc3k_processed/obsp/connectivities TIME 0.084
    START  WRITING tiledb-data/pbmc3k_processed/raw
    START  WRITING tiledb-data/pbmc3k_processed/raw/X/data from <class 'scipy.sparse._csr.csr_matrix'>
      START  __ingest_coo_data_rows_chunked
        START  chunk rows 0..2638 of 2638, obs_ids AAACATACAACCAC-1..TTTGCATGCCTCAC-1, nnz=2238732, 100.000%
        FINISH chunk TIME 2.307
      FINISH __ingest_coo_data_rows_chunked TIME 2.521
    FINISH WRITING tiledb-data/pbmc3k_processed/raw/X/data TIME 2.535
    START  WRITING tiledb-data/pbmc3k_processed/raw/var
    FINISH WRITING tiledb-data/pbmc3k_processed/raw/var TIME 0.034
    FINISH WRITING tiledb-data/pbmc3k_processed/raw TIME 2.573
  FINISH WRITING tiledb-data/pbmc3k_processed TIME 6.376
FINISH SOMA.from_h5ad anndata/pbmc3k_processed.h5ad -> tiledb-data/pbmc3k_processed TIME 6.639
```