### PR TITLE
Add a soma.to_anndata_from_raw method

### DIFF
--- a/apis/python/src/tiledbsc/soma.py
+++ b/apis/python/src/tiledbsc/soma.py
@@ -2,7 +2,7 @@ import os
 from typing import Optional, Union
 
 import anndata as ad
-import numpy
+import numpy   as np
 import pandas  as pd
 import pyarrow as pa
 import scanpy
@@ -801,7 +801,7 @@ class SOMA():
         # with csr[permuation[28]] -- the CSR matrix itself isn't sorted in bulk.
         sorted_row_names, permutation = util.get_sort_and_permutation(list(row_names))
         # Using numpy we can index this with a list of indices, which a plain Python list doesn't support.
-        sorted_row_names = numpy.asarray(sorted_row_names)
+        sorted_row_names = np.asarray(sorted_row_names)
 
         s = util.get_start_stamp()
         if self.verbose:

--- a/apis/python/src/tiledbsc/soma.py
+++ b/apis/python/src/tiledbsc/soma.py
@@ -2,7 +2,7 @@ import os
 from typing import Optional, Union
 
 import anndata as ad
-import numpy   as np
+import numpy
 import pandas  as pd
 import pyarrow as pa
 import scanpy
@@ -801,7 +801,7 @@ class SOMA():
         # with csr[permuation[28]] -- the CSR matrix itself isn't sorted in bulk.
         sorted_row_names, permutation = util.get_sort_and_permutation(list(row_names))
         # Using numpy we can index this with a list of indices, which a plain Python list doesn't support.
-        sorted_row_names = np.asarray(sorted_row_names)
+        sorted_row_names = numpy.asarray(sorted_row_names)
 
         s = util.get_start_stamp()
         if self.verbose:

--- a/apis/python/tests/test_anndata_uns.py
+++ b/apis/python/tests/test_anndata_uns.py
@@ -4,7 +4,6 @@ from tiledbsc import SOMA
 import pandas as pd
 import numpy as np
 from scipy import sparse
-import os
 
 from collections import OrderedDict
 import os
@@ -46,18 +45,6 @@ def test_from_anndata_uns(tmp_path):
             index=np.arange(10).astype(str), data={"A": np.arange(10, dtype=np.int32)}
         ),
     }
-
-# int
-# float
-# list_of_float
-# list_of_int
-# list_of_string
-# numpy_ndarray_1d_int
-# numpy_ndarray_1d_string
-# numpy_ndarray_2d_float
-# pandas_dataframe
-# simple_dict
-# string
 
     adata = AnnData(X=X, obs=obs, var=var, uns=uns)
 

--- a/apis/python/tests/test_anndata_uns.py
+++ b/apis/python/tests/test_anndata_uns.py
@@ -53,9 +53,9 @@ def test_from_anndata_uns(tmp_path):
     unspath = tmp_path / "uns"
     assert os.path.exists(unspath)
     for key in uns.keys():
-        assert os.path.exists(os.path.join(unspath, key))
+        assert os.path.exists("/".join([unspath, key]))
 
-    with tiledb.open(os.path.join(unspath, "int")) as A:
+    with tiledb.open("/".join([unspath, "int"])) as A:
         df = A[:]
         assert isinstance(df, np.ndarray)
         assert(df.shape == (1,))
@@ -63,77 +63,77 @@ def test_from_anndata_uns(tmp_path):
         assert(df.dtype == np.int64 or df.dtype == np.int32)
         assert df[0] == 1
 
-    with tiledb.open(os.path.join(unspath, "float")) as A:
+    with tiledb.open("/".join([unspath, "float"])) as A:
         df = A[:]
         assert isinstance(df, np.ndarray)
         assert(df.shape == (1,))
         assert(df.dtype == np.float64)
         assert df[0] == 3.25
 
-    with tiledb.open(os.path.join(unspath, "string")) as A:
+    with tiledb.open("/".join([unspath, "string"])) as A:
         df = A[:]
         assert isinstance(df, np.ndarray)
         assert(df.shape == (1,))
         assert(df.dtype == np.dtype('O'))
         assert df[0] == "a string"
 
-    with tiledb.open(os.path.join(unspath, "list_of_int")) as A:
+    with tiledb.open("/".join([unspath, "list_of_int"])) as A:
         df = A[:]
         assert isinstance(df, np.ndarray)
         assert(df.shape == (10,))
         assert(df.dtype == np.int64 or df.dtype == np.int32)
         assert df[9] == 90
 
-    with tiledb.open(os.path.join(unspath, "list_of_float")) as A:
+    with tiledb.open("/".join([unspath, "list_of_float"])) as A:
         df = A[:]
         assert isinstance(df, np.ndarray)
         assert(df.shape == (10,))
         assert(df.dtype == np.float64)
         assert df[9] == 11.25
 
-    with tiledb.open(os.path.join(unspath, "list_of_string")) as A:
+    with tiledb.open("/".join([unspath, "list_of_string"])) as A:
         df = A[:]
         assert isinstance(df, np.ndarray)
         assert(df.shape == (10,))
         assert(df.dtype == np.dtype('O'))
         assert df[9] == "900"
 
-    with tiledb.open(os.path.join(unspath, "simple_dict", "A")) as A:
+    with tiledb.open("/".join([unspath, "simple_dict", "A"])) as A:
         df = A[:]
         assert isinstance(df, np.ndarray)
         assert(df.shape == (1,))
         assert(df.dtype == np.int64 or df.dtype == np.int32)
         assert df[0] == 0
 
-    with tiledb.open(os.path.join(unspath, "simple_dict", "B")) as A:
+    with tiledb.open("/".join([unspath, "simple_dict", "B"])) as A:
         df = A[:]
         assert isinstance(df, np.ndarray)
         assert(df.shape == (1,))
         assert(df.dtype == np.dtype('O'))
         assert df[0] == "one"
 
-    with tiledb.open(os.path.join(unspath, "numpy_ndarray_1d_int")) as A:
+    with tiledb.open("/".join([unspath, "numpy_ndarray_1d_int"])) as A:
         df = A[:]
         assert isinstance(df, np.ndarray)
         assert(df.shape == (3,))
         assert(df.dtype == np.int64 or df.dtype == np.int32)
         assert df[2] == 3
 
-    with tiledb.open(os.path.join(unspath, "numpy_ndarray_2d_float")) as A:
+    with tiledb.open("/".join([unspath, "numpy_ndarray_2d_float"])) as A:
         df = A[:]
         assert isinstance(df, np.ndarray)
         assert(df.shape == (2,3))
         assert(df.dtype == np.float64)
         assert df[1][2] == 6.0
 
-    with tiledb.open(os.path.join(unspath, "numpy_ndarray_1d_string")) as A:
+    with tiledb.open("/".join([unspath, "numpy_ndarray_1d_string"])) as A:
         df = A[:]
         assert isinstance(df, np.ndarray)
         assert(df.shape == (3,))
         assert(df.dtype == np.dtype('O'))
         assert df[2] == 'c'
 
-    with tiledb.open(os.path.join(unspath, "pandas_dataframe")) as A:
+    with tiledb.open("/".join([unspath, "pandas_dataframe"])) as A:
         df = A[:]
         assert isinstance(df, OrderedDict)
         dfa = df['A']

--- a/apis/python/tests/test_anndata_uns.py
+++ b/apis/python/tests/test_anndata_uns.py
@@ -47,6 +47,18 @@ def test_from_anndata_uns(tmp_path):
         ),
     }
 
+# int
+# float
+# list_of_float
+# list_of_int
+# list_of_string
+# numpy_ndarray_1d_int
+# numpy_ndarray_1d_string
+# numpy_ndarray_2d_float
+# pandas_dataframe
+# simple_dict
+# string
+
     adata = AnnData(X=X, obs=obs, var=var, uns=uns)
 
     SOMA(tmp_path.as_posix()).from_anndata(adata)

--- a/apis/python/tests/test_anndata_uns.py
+++ b/apis/python/tests/test_anndata_uns.py
@@ -4,6 +4,7 @@ from tiledbsc import SOMA
 import pandas as pd
 import numpy as np
 from scipy import sparse
+import os
 
 from collections import OrderedDict
 import os

--- a/apis/python/tests/test_anndata_uns.py
+++ b/apis/python/tests/test_anndata_uns.py
@@ -53,9 +53,9 @@ def test_from_anndata_uns(tmp_path):
     unspath = tmp_path / "uns"
     assert os.path.exists(unspath)
     for key in uns.keys():
-        assert os.path.exists("/".join([unspath, key]))
+        assert (unspath / key).exists()
 
-    with tiledb.open("/".join([unspath, "int"])) as A:
+    with tiledb.open((unspath / "int").as_posix()) as A:
         df = A[:]
         assert isinstance(df, np.ndarray)
         assert(df.shape == (1,))
@@ -63,77 +63,77 @@ def test_from_anndata_uns(tmp_path):
         assert(df.dtype == np.int64 or df.dtype == np.int32)
         assert df[0] == 1
 
-    with tiledb.open("/".join([unspath, "float"])) as A:
+    with tiledb.open((unspath / "float").as_posix()) as A:
         df = A[:]
         assert isinstance(df, np.ndarray)
         assert(df.shape == (1,))
         assert(df.dtype == np.float64)
         assert df[0] == 3.25
 
-    with tiledb.open("/".join([unspath, "string"])) as A:
+    with tiledb.open((unspath / "string").as_posix()) as A:
         df = A[:]
         assert isinstance(df, np.ndarray)
         assert(df.shape == (1,))
         assert(df.dtype == np.dtype('O'))
         assert df[0] == "a string"
 
-    with tiledb.open("/".join([unspath, "list_of_int"])) as A:
+    with tiledb.open((unspath / "list_of_int").as_posix()) as A:
         df = A[:]
         assert isinstance(df, np.ndarray)
         assert(df.shape == (10,))
         assert(df.dtype == np.int64 or df.dtype == np.int32)
         assert df[9] == 90
 
-    with tiledb.open("/".join([unspath, "list_of_float"])) as A:
+    with tiledb.open((unspath / "list_of_float").as_posix()) as A:
         df = A[:]
         assert isinstance(df, np.ndarray)
         assert(df.shape == (10,))
         assert(df.dtype == np.float64)
         assert df[9] == 11.25
 
-    with tiledb.open("/".join([unspath, "list_of_string"])) as A:
+    with tiledb.open((unspath / "list_of_string").as_posix()) as A:
         df = A[:]
         assert isinstance(df, np.ndarray)
         assert(df.shape == (10,))
         assert(df.dtype == np.dtype('O'))
         assert df[9] == "900"
 
-    with tiledb.open("/".join([unspath, "simple_dict", "A"])) as A:
+    with tiledb.open((unspath / "simple_dict" / "A").as_posix()) as A:
         df = A[:]
         assert isinstance(df, np.ndarray)
         assert(df.shape == (1,))
         assert(df.dtype == np.int64 or df.dtype == np.int32)
         assert df[0] == 0
 
-    with tiledb.open("/".join([unspath, "simple_dict", "B"])) as A:
+    with tiledb.open((unspath / "simple_dict" / "B").as_posix()) as A:
         df = A[:]
         assert isinstance(df, np.ndarray)
         assert(df.shape == (1,))
         assert(df.dtype == np.dtype('O'))
         assert df[0] == "one"
 
-    with tiledb.open("/".join([unspath, "numpy_ndarray_1d_int"])) as A:
+    with tiledb.open((unspath / "numpy_ndarray_1d_int").as_posix()) as A:
         df = A[:]
         assert isinstance(df, np.ndarray)
         assert(df.shape == (3,))
         assert(df.dtype == np.int64 or df.dtype == np.int32)
         assert df[2] == 3
 
-    with tiledb.open("/".join([unspath, "numpy_ndarray_2d_float"])) as A:
+    with tiledb.open((unspath / "numpy_ndarray_2d_float").as_posix()) as A:
         df = A[:]
         assert isinstance(df, np.ndarray)
         assert(df.shape == (2,3))
         assert(df.dtype == np.float64)
         assert df[1][2] == 6.0
 
-    with tiledb.open("/".join([unspath, "numpy_ndarray_1d_string"])) as A:
+    with tiledb.open((unspath / "numpy_ndarray_1d_string").as_posix()) as A:
         df = A[:]
         assert isinstance(df, np.ndarray)
         assert(df.shape == (3,))
         assert(df.dtype == np.dtype('O'))
         assert df[2] == 'c'
 
-    with tiledb.open("/".join([unspath, "pandas_dataframe"])) as A:
+    with tiledb.open((unspath / "pandas_dataframe").as_posix()) as A:
         df = A[:]
         assert isinstance(df, OrderedDict)
         dfa = df['A']

--- a/apis/python/tests/test_anndata_uns.py
+++ b/apis/python/tests/test_anndata_uns.py
@@ -53,9 +53,9 @@ def test_from_anndata_uns(tmp_path):
     unspath = tmp_path / "uns"
     assert os.path.exists(unspath)
     for key in uns.keys():
-        assert (unspath / key).exists()
+        assert os.path.exists(os.path.join(unspath, key))
 
-    with tiledb.open((unspath / "int").as_posix()) as A:
+    with tiledb.open(os.path.join(unspath, "int")) as A:
         df = A[:]
         assert isinstance(df, np.ndarray)
         assert(df.shape == (1,))
@@ -63,77 +63,77 @@ def test_from_anndata_uns(tmp_path):
         assert(df.dtype == np.int64 or df.dtype == np.int32)
         assert df[0] == 1
 
-    with tiledb.open((unspath / "float").as_posix()) as A:
+    with tiledb.open(os.path.join(unspath, "float")) as A:
         df = A[:]
         assert isinstance(df, np.ndarray)
         assert(df.shape == (1,))
         assert(df.dtype == np.float64)
         assert df[0] == 3.25
 
-    with tiledb.open((unspath / "string").as_posix()) as A:
+    with tiledb.open(os.path.join(unspath, "string")) as A:
         df = A[:]
         assert isinstance(df, np.ndarray)
         assert(df.shape == (1,))
         assert(df.dtype == np.dtype('O'))
         assert df[0] == "a string"
 
-    with tiledb.open((unspath / "list_of_int").as_posix()) as A:
+    with tiledb.open(os.path.join(unspath, "list_of_int")) as A:
         df = A[:]
         assert isinstance(df, np.ndarray)
         assert(df.shape == (10,))
         assert(df.dtype == np.int64 or df.dtype == np.int32)
         assert df[9] == 90
 
-    with tiledb.open((unspath / "list_of_float").as_posix()) as A:
+    with tiledb.open(os.path.join(unspath, "list_of_float")) as A:
         df = A[:]
         assert isinstance(df, np.ndarray)
         assert(df.shape == (10,))
         assert(df.dtype == np.float64)
         assert df[9] == 11.25
 
-    with tiledb.open((unspath / "list_of_string").as_posix()) as A:
+    with tiledb.open(os.path.join(unspath, "list_of_string")) as A:
         df = A[:]
         assert isinstance(df, np.ndarray)
         assert(df.shape == (10,))
         assert(df.dtype == np.dtype('O'))
         assert df[9] == "900"
 
-    with tiledb.open((unspath / "simple_dict" / "A").as_posix()) as A:
+    with tiledb.open(os.path.join(unspath, "simple_dict", "A")) as A:
         df = A[:]
         assert isinstance(df, np.ndarray)
         assert(df.shape == (1,))
         assert(df.dtype == np.int64 or df.dtype == np.int32)
         assert df[0] == 0
 
-    with tiledb.open((unspath / "simple_dict" / "B").as_posix()) as A:
+    with tiledb.open(os.path.join(unspath, "simple_dict", "B")) as A:
         df = A[:]
         assert isinstance(df, np.ndarray)
         assert(df.shape == (1,))
         assert(df.dtype == np.dtype('O'))
         assert df[0] == "one"
 
-    with tiledb.open((unspath / "numpy_ndarray_1d_int").as_posix()) as A:
+    with tiledb.open(os.path.join(unspath, "numpy_ndarray_1d_int")) as A:
         df = A[:]
         assert isinstance(df, np.ndarray)
         assert(df.shape == (3,))
         assert(df.dtype == np.int64 or df.dtype == np.int32)
         assert df[2] == 3
 
-    with tiledb.open((unspath / "numpy_ndarray_2d_float").as_posix()) as A:
+    with tiledb.open(os.path.join(unspath, "numpy_ndarray_2d_float")) as A:
         df = A[:]
         assert isinstance(df, np.ndarray)
         assert(df.shape == (2,3))
         assert(df.dtype == np.float64)
         assert df[1][2] == 6.0
 
-    with tiledb.open((unspath / "numpy_ndarray_1d_string").as_posix()) as A:
+    with tiledb.open(os.path.join(unspath, "numpy_ndarray_1d_string")) as A:
         df = A[:]
         assert isinstance(df, np.ndarray)
         assert(df.shape == (3,))
         assert(df.dtype == np.dtype('O'))
         assert df[2] == 'c'
 
-    with tiledb.open((unspath / "pandas_dataframe").as_posix()) as A:
+    with tiledb.open(os.path.join(unspath, "pandas_dataframe")) as A:
         df = A[:]
         assert isinstance(df, OrderedDict)
         dfa = df['A']


### PR DESCRIPTION
This is a for-now way to extract out `raw/X`, `obs`, and `raw/var` from a SOMA group and write it to its own `.h5ad` file.

The code is in motion due to https://github.com/single-cell-data/TileDB-SingleCell/issues/72 which is currently active, so the implementation of this will change -- nonetheless (a) this works today, and (b) it will continue to work (albeit spelled differently) in the future.

Example:

```
$ ./ingestor.py anndata/pbmc3k_processed.h5ad tiledb-data/pbmc3k_processed
```

```
>>> import tiledbsc

>>> soma = tiledbsc.SOMA('tiledb-data/pbmc3k_processed')

>>> a = soma.to_anndata()
START  SOMA.to_anndata tiledb-data/pbmc3k_processed
  START  read tiledb-data/pbmc3k_processed/obs
  FINISH read tiledb-data/pbmc3k_processed/obs TIME 0.283
  START  read tiledb-data/pbmc3k_processed/var
  FINISH read tiledb-data/pbmc3k_processed/var TIME 0.010
  START  read tiledb-data/pbmc3k_processed/X/data
  FINISH read tiledb-data/pbmc3k_processed/X/data TIME 3.589
  X/RAW OUTGEST NOT IMPLMENTED YET
  START  read tiledb-data/pbmc3k_processed/obsm
    START  read file:///Users/johnkerl/git/single-cell-data/TileDB-SingleCell/apis/python/tiledb-data/pbmc3k_processed/obsm/X_umap
    FINISH read file:///Users/johnkerl/git/single-cell-data/TileDB-SingleCell/apis/python/tiledb-data/pbmc3k_processed/obsm/X_umap TIME 0.014
    START  read file:///Users/johnkerl/git/single-cell-data/TileDB-SingleCell/apis/python/tiledb-data/pbmc3k_processed/obsm/X_tsne
    FINISH read file:///Users/johnkerl/git/single-cell-data/TileDB-SingleCell/apis/python/tiledb-data/pbmc3k_processed/obsm/X_tsne TIME 0.009
    START  read file:///Users/johnkerl/git/single-cell-data/TileDB-SingleCell/apis/python/tiledb-data/pbmc3k_processed/obsm/X_pca
    FINISH read file:///Users/johnkerl/git/single-cell-data/TileDB-SingleCell/apis/python/tiledb-data/pbmc3k_processed/obsm/X_pca TIME 0.036
    START  read file:///Users/johnkerl/git/single-cell-data/TileDB-SingleCell/apis/python/tiledb-data/pbmc3k_processed/obsm/X_draw_graph_fr
    FINISH read file:///Users/johnkerl/git/single-cell-data/TileDB-SingleCell/apis/python/tiledb-data/pbmc3k_processed/obsm/X_draw_graph_fr TIME 0.008
  FINISH read tiledb-data/pbmc3k_processed/obsm TIME 0.080
  START  read tiledb-data/pbmc3k_processed/varm
    START  read file:///Users/johnkerl/git/single-cell-data/TileDB-SingleCell/apis/python/tiledb-data/pbmc3k_processed/varm/PCs
    FINISH read file:///Users/johnkerl/git/single-cell-data/TileDB-SingleCell/apis/python/tiledb-data/pbmc3k_processed/varm/PCs TIME 0.031
  FINISH read tiledb-data/pbmc3k_processed/varm TIME 0.034
  OBSP OUTGEST NOT WORKING YET
  VARP OUTGEST NOT WORKING YET
FINISH SOMA.to_anndata tiledb-data/pbmc3k_processed TIME 4.218

>>> b = soma.to_anndata_from_raw()
  START  read tiledb-data/pbmc3k_processed/obs
  FINISH read tiledb-data/pbmc3k_processed/obs TIME 0.014
  START  read tiledb-data/pbmc3k_processed/raw/var
  FINISH read tiledb-data/pbmc3k_processed/raw/var TIME 0.017
  START  read tiledb-data/pbmc3k_processed/raw/X/data
  FINISH read tiledb-data/pbmc3k_processed/raw/X/data TIME 1.763

>>> a.write_h5ad('cooked.h5ad')

>>> b.write_h5ad('raw.h5ad')
```

```
$ ./desc-ann.py cooked.h5ad

================================================================ cooked.h5ad

----------------------------------------------------------------
ANNDATA SUMMARY:
AnnData object with n_obs × n_vars = 2638 × 1838
    obs: 'n_genes', 'percent_mito', 'n_counts', 'louvain'
    var: 'n_cells'
    obsm: 'X_draw_graph_fr', 'X_pca', 'X_tsne', 'X_umap'
    varm: 'PCs'
X SHAPE   (2638, 1838)
OBS  LEN  2638
VAR  LEN  1838
OBS IS A <class 'pandas.core.frame.DataFrame'>
   n_genes int64
   percent_mito float32
   n_counts float32
   louvain category
VAR IS A <class 'pandas.core.frame.DataFrame'>
   n_cells int64
OBS  KEYS ['n_genes', 'percent_mito', 'n_counts', 'louvain']
VAR  KEYS ['n_cells']
OBSM KEYS ['X_draw_graph_fr', 'X_pca', 'X_tsne', 'X_umap']
VARM KEYS ['PCs']
OBSP KEYS []
VARP KEYS []

----------------------------------------------------------------
ANNDATA FILE TYPES:
X/data                                   <class 'scipy.sparse._csr.csr_matrix'>
X/data shape                             (2638, 1838)
X/data dtype                             float32
X/data density                           1.0000
obs                                      <class 'pandas.core.frame.DataFrame'>
var                                      <class 'pandas.core.frame.DataFrame'>
obsm/X_draw_graph_fr                     <class 'numpy.ndarray'>
obsm/X_pca                               <class 'numpy.ndarray'>
obsm/X_tsne                              <class 'numpy.ndarray'>
obsm/X_umap                              <class 'numpy.ndarray'>
varm/PCs                                 <class 'numpy.ndarray'>
```

```
$ ./desc-ann.py raw.h5ad

================================================================ raw.h5ad

----------------------------------------------------------------
ANNDATA SUMMARY:
AnnData object with n_obs × n_vars = 2638 × 13714
    obs: 'n_genes', 'percent_mito', 'n_counts', 'louvain'
    var: 'n_cells'
X SHAPE   (2638, 13714)
OBS  LEN  2638
VAR  LEN  13714
OBS IS A <class 'pandas.core.frame.DataFrame'>
   n_genes int64
   percent_mito float32
   n_counts float32
   louvain category
VAR IS A <class 'pandas.core.frame.DataFrame'>
   n_cells int64
OBS  KEYS ['n_genes', 'percent_mito', 'n_counts', 'louvain']
VAR  KEYS ['n_cells']
OBSM KEYS []
VARM KEYS []
OBSP KEYS []
VARP KEYS []

----------------------------------------------------------------
ANNDATA FILE TYPES:
X/data                                   <class 'scipy.sparse._csr.csr_matrix'>
X/data shape                             (2638, 13714)
X/data dtype                             float32
X/data density                           0.0619
obs                                      <class 'pandas.core.frame.DataFrame'>
var                                      <class 'pandas.core.frame.DataFrame'>
```