### PR TITLE
Print chunk-ingest ETA

### DIFF
--- a/apis/python/setup.cfg
+++ b/apis/python/setup.cfg
@@ -32,7 +32,7 @@ zip_safe = False
 # The numpy pin is to avoid
 # "ImportError: Numba needs NumPy 1.21 or less"
 install_requires =
-    tiledb>=0.14.1
+    tiledb>=0.14.5
     scipy
     numpy<1.22
     pandas

--- a/apis/python/src/tiledbsc/util.py
+++ b/apis/python/src/tiledbsc/util.py
@@ -7,7 +7,7 @@ import scipy
 import pandas as pd
 
 import time
-from typing import Optional
+from typing import Optional, List
 
 # ----------------------------------------------------------------
 def get_start_stamp():
@@ -23,7 +23,7 @@ def format_elapsed(start_stamp, message: str):
     Returns the message along with an elapsed-time indicator, with end time relative to start
     start from get_start_stamp. Used for annotating elapsed time of a task.
     """
-    return "%s TIME %.3f" % (message, time.time() - start_stamp)
+    return "%s TIME %.3f seconds" % (message, time.time() - start_stamp)
 
 # ----------------------------------------------------------------
 def find_csr_chunk_size(mat: scipy.sparse._csr.csr_matrix, permutation: list, start_row_index: int, goal_chunk_nnz: int):
@@ -127,3 +127,75 @@ def _to_tiledb_supported_array_type(x):
 
     target_dtype = _to_tiledb_supported_dtype(x.dtype)
     return x if target_dtype == x.dtype else x.astype(target_dtype)
+
+# ================================================================
+class ETATracker:
+    """
+    Computes estimated time to completion for chunked writes.
+    """
+    percents: List[float]
+    cumulative_seconds: List[float]
+
+    def __init__(self):
+        self.chunk_percents = []
+        self.cumulative_seconds = []
+
+    def ingest_and_predict(self, chunk_percent: float, chunk_seconds: float) -> str:
+        """
+        Updates from most recent chunk percent-done and chunk completion-seconds, then does a linear
+        regression on all chunks done so far and estimates time to completion.
+        :param chunk_percent: a percent done like 6.1 or 10.3.
+        :param chunk_seconds: number of seconds it took to do the current chunk operation.
+        """
+        self._ingest(chunk_percent, chunk_seconds)
+        eta_seconds = self._predict()
+        eta_format = self._format_seconds(eta_seconds)
+        return eta_format
+
+    def _ingest(self, chunk_percent: float, chunk_seconds: float) -> None:
+        """
+        Takes the current percent done like 10.3 and current chunk seconds like 58.4 and grows an
+        array of percent-dones and cumulative seconds. This means self.chunk_percents is a list of
+        all the chunk_percent arguments from calling _ingest, while each self.chunk_seconds slot is
+        the sum of all previous chunk_seconds arguments from calling _ingest.
+        """
+        if len(self.chunk_percents) == 0:
+            self.chunk_percents = [chunk_percent]
+            self.cumulative_seconds = [chunk_seconds]
+        else:
+            self.chunk_percents.append(chunk_percent)
+            self.cumulative_seconds.append(self.cumulative_seconds[-1] + chunk_seconds)
+
+    def _predict(self) -> float:
+        """
+        Does a linear regression on all chunks done so far and estimates time to completion.
+        Returns ETA seconds as a number.
+        """
+        # Linear regression where x is cumulative seconds and y is percent done.
+        x = numpy.array(self.cumulative_seconds)
+        y = numpy.array(self.chunk_percents)
+        A = numpy.vstack([x, numpy.ones(len(x))]).T
+        m, b = numpy.linalg.lstsq(A, y, rcond=None)[0]
+        # Solve for x where y == 100
+        done_cumu_seconds = (100.0 - b) / m
+
+        return done_cumu_seconds - self.cumulative_seconds[-1]
+
+    def _format_seconds(self, seconds: float) -> str:
+        """
+        Formats the ETA seconds as a compact, human-readable string.
+        """
+        if seconds >= 86400:
+            return "%.2f days" % (seconds/86400)
+        elif seconds >= 3600:
+            return "%.2f hours" % (seconds/3600)
+        elif seconds >= 60:
+            return "%.2f minutes" % (seconds/60)
+        else:
+            return "%.2f seconds" % (seconds)
+
+    def __str__(self):
+        return str(self.chunk_percents) + " " + str(self.cumulative_seconds)
+
+    def __repr__(self):
+        return self.__str__()


### PR DESCRIPTION
Ingesting larger `.h5ad` files can take a while, principally in `X/data` and `raw/X/data`: on my laptop, anyway, a few hours total for a muiti-gigabyte file. On this PR we offer an ETA for each chunked ingest:

```
$ ingestor.py --ifexists replace anndata/tabula-sapiens-immune.h5ad
START  SOMA.from_h5ad anndata/tabula-sapiens-immune.h5ad -> ./tiledb-data/tabula-sapiens-immune
START  READING anndata/tabula-sapiens-immune.h5ad
FINISH READING anndata/tabula-sapiens-immune.h5ad TIME 58.058 seconds
START  DECATEGORICALIZING
FINISH DECATEGORICALIZING TIME 1.817 seconds
START  WRITING ./tiledb-data/tabula-sapiens-immune
Creating TileDB group ./tiledb-data/tabula-sapiens-immune
  Creating TileDB group ./tiledb-data/tabula-sapiens-immune/X
    START  WRITING ./tiledb-data/tabula-sapiens-immune/X/data
    START  __ingest_coo_data_string_dims_rows_chunked
    START  chunk rows 0..4543 of 264824 (1.715%), obs_ids AAACCCAAGAAACTGT_TSP7_LymphNodes_Inguinal_10X_1_1..AACCATGGTAGTGTGG_TSP2_Blood_NA_10X_1_3, nnz=10000766
    FINISH chunk in 78.118 seconds,   1.715% done, ETA 1.24 hours
    START  chunk rows 4544..9084 of 264824 (3.430%), obs_ids AACCATGGTATTTCTC_TSP14_LymphNode_NA_10X_1_1..AAGGTAACACAGCTGC_TSP7_Blood_NA_10X_2_1, nnz=10000256
...
```

FYI, current mini-corpus (on my laptop) drawn from https://cellxgene.cziscience.com/ along with issues on this repo:

<details>

```
$ du -hs anndata/* | gmsort
 36K	anndata/subset_100_100.h5ad
 72K	anndata/bruce-nan.h5ad
232K	anndata/pbmc-small.h5ad
4.3M	anndata/10x_pbmc68k_reduced.h5ad
4.6M	anndata/bruce-spatial.h5ad
 27M	anndata/af9d8c03-696c-4997-bde8-8ef00844881b.h5ad
 30M	anndata/d4db74ad-a129-4b1a-b9da-1b30db86bbe4-issue-74.h5ad
 32M	anndata/bruce-559.h5ad
 32M	anndata/Puck_200903_10.h5ad
 36M	anndata/local3.h5ad
 38M	anndata/pbmc3k_processed.h5ad
 40M	anndata/brown-adipose-tissue-mouse.h5ad
 47M	anndata/pbmc3k-krilow.h5ad
 51M	anndata/0cfab2d4-1b79-444e-8cbe-2ca9671ca85e.h5ad
 55M	anndata/4056cbab-2a32-4c9e-a55f-c930bc793fb6.h5ad
 70M	anndata/human-kidney-tumors-wilms.h5ad
 99M	anndata/issue-71.h5ad
117M	anndata/adult-mouse-cortical-cell-taxonomy.h5ad
119M	anndata/longitudinal-profiling-49.h5ad
221M	anndata/single-cell-transcriptomes.h5ad
230M	anndata/Single_cell_atlas_of_peripheral_immune_response_to_SARS_CoV_2_infection.h5ad
231M	anndata/vieira19_Alveoli_and_parenchyma_anonymised.processed.h5ad
312M	anndata/pbmc-chad.h5ad
329M	anndata/local2.h5ad
357M	anndata/issue-69.h5ad
376M	anndata/acute-covid19-cohort.h5ad
686M	anndata/autoimmunity-pbmcs.h5ad
712M	anndata/developmental-single-cell-atlas-of-the-murine-lung.h5ad
2.5G	anndata/tabula-sapiens-stromal.h5ad
3.2G	anndata/tabula-sapiens-epithelial.h5ad
5.6G	anndata/integrated-human-lung-cell-atlas.h5ad
5.7G	anndata/tabula-sapiens-immune.h5ad
6.6G	anndata/azimuth-meta-analysis.h5ad

$ du -hs tiledb-data/* | gmsort
104K	tiledb-data/subset_100_100
448K	tiledb-data/bruce-nan
548K	tiledb-data/pbmc-small
2.6M	tiledb-data/bruce-spatial
2.9M	tiledb-data/10x_pbmc68k_reduced
 24M	tiledb-data/af9d8c03-696c-4997-bde8-8ef00844881b
 28M	tiledb-data/bruce-559
 28M	tiledb-data/local3
 33M	tiledb-data/pbmc3k_processed
 34M	tiledb-data/pbmc3k-krilow
 36M	tiledb-data/Puck_200903_10
 38M	tiledb-data/brown-adipose-tissue-mouse
 41M	tiledb-data/d4db74ad-a129-4b1a-b9da-1b30db86bbe4-issue-74
 50M	tiledb-data/0cfab2d4-1b79-444e-8cbe-2ca9671ca85e
 53M	tiledb-data/4056cbab-2a32-4c9e-a55f-c930bc793fb6
 72M	tiledb-data/human-kidney-tumors-wilms
 91M	tiledb-data/issue-71
115M	tiledb-data/adult-mouse-cortical-cell-taxonomy
119M	tiledb-data/longitudinal-profiling-49
160M	tiledb-data/vieira19_Alveoli_and_parenchyma_anonymised.processed
232M	tiledb-data/single-cell-transcriptomes
301M	tiledb-data/Single_cell_atlas_of_peripheral_immune_response_to_SARS_CoV_2_infection
365M	tiledb-data/local2
387M	tiledb-data/pbmc-chad
396M	tiledb-data/acute-covid19-cohort
553M	tiledb-data/issue-69
732M	tiledb-data/developmental-single-cell-atlas-of-the-murine-lung
733M	tiledb-data/autoimmunity-pbmcs
2.1G	tiledb-data/tabula-sapiens-stromal
2.7G	tiledb-data/tabula-sapiens-epithelial
4.7G	tiledb-data/tabula-sapiens-immune
6.0G	tiledb-data/integrated-human-lung-cell-atlas
6.7G	tiledb-data/azimuth-meta-analysis

```

</details>
