### PR TITLE
Add Python-formatter to CI for Python code

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,0 +1,22 @@
+name: TileDB Python Linting
+
+on: [push, pull_request]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+
+      - name: Check Python Black Format
+        uses: psf/black@stable
+        with:
+          options: "apis/python --check"
+
+# TODO
+#      - name: Check Clang-Format
+#        uses: DoozyX/clang-format-lint-action@v0.13
+#        with:
+#          clangFormatVersion: '10'
+#          source: 'tiledb'


### PR DESCRIPTION
Great advice from @Shelnutt2.

This is an automated enforced for the manual run done on #92.

Help standardize the code coming out this week for #95.

Note: `black` is already in our `apis/python/setup.cfg`.