### PR TITLE
'for matrix in soma.obsm: ...' et al

### DIFF
--- a/apis/python/src/tiledbsc/annotation_matrix_group.py
+++ b/apis/python/src/tiledbsc/annotation_matrix_group.py
@@ -7,7 +7,7 @@ import tiledbsc.util as util
 import pandas as pd
 import scipy
 
-from typing import Optional, Dict
+from typing import Optional, Dict, List
 import os
 
 
@@ -39,6 +39,19 @@ class AnnotationMatrixGroup(TileDBGroup):
         accessor `.get_member_names()`.
         """
         return self.get_member_names()
+
+    # ----------------------------------------------------------------
+    def __iter__(self) -> List[AnnotationMatrix]:
+        """
+        Implements 'for matrix in soma.obsm: ...' and 'for matrix in soma.varm: ...'
+        """
+        retval = []
+        for name, uri in self.get_member_names_to_uris().items():
+            matrix = AnnotationMatrix(
+                uri=uri, name=name, dim_name=self.dim_name, parent=self
+            )
+            retval.append(matrix)
+        return iter(retval)
 
     # ----------------------------------------------------------------
     def from_anndata(self, annotation_matrices, dim_values):

--- a/apis/python/src/tiledbsc/annotation_pairwise_matrix_group.py
+++ b/apis/python/src/tiledbsc/annotation_pairwise_matrix_group.py
@@ -8,7 +8,7 @@ import tiledbsc.util as util
 import pandas as pd
 import scipy
 
-from typing import Optional, Dict
+from typing import Optional, Dict, List
 import os
 
 
@@ -45,6 +45,23 @@ class AnnotationPairwiseMatrixGroup(TileDBGroup):
         accessor `.get_member_names()`.
         """
         return self.get_member_names()
+
+    # ----------------------------------------------------------------
+    def __iter__(self) -> List[AnnotationPairwiseMatrix]:
+        """
+        Implements 'for matrix in soma.obsp: ...' and 'for matrix in soma.varp: ...'
+        """
+        retval = []
+        for name, uri in self.get_member_names_to_uris().items():
+            matrix = AnnotationPairwiseMatrix(
+                uri=uri,
+                name=name,
+                row_dim_name=self.row_dim_name,
+                col_dim_name=self.col_dim_name,
+                parent=self,
+            )
+            retval.append(matrix)
+        return iter(retval)
 
     # ----------------------------------------------------------------
     def from_anndata(self, annotation_pairwise_matrices, dim_values):

--- a/apis/python/tests/test_soma_group_indexing.py
+++ b/apis/python/tests/test_soma_group_indexing.py
@@ -185,3 +185,14 @@ def test_soma_group_indexing(h5ad_file):
     assert set(soma.uns["neighbors"]["params"].get_member_names()) == set(["method"])
     assert isinstance(soma.uns["neighbors"]["params"]["method"], tiledbsc.UnsArray)
     assert soma.uns["nonesuch"] is None
+
+    # These print to stdout -- here we exercise just them to make sure they're not throwing
+    # exceptions.
+    for e in soma.obsm:
+        print(e.name, e.shape(), e.uri)
+    for e in soma.varm:
+        print(e.name, e.shape(), e.uri)
+    for e in soma.obsp:
+        print(e.name, e.shape(), e.uri)
+    for e in soma.varp:
+        print(e.name, e.shape(), e.uri)


### PR DESCRIPTION
This allows nice syntax like:

```
soma = tiledbsc.SOMA('/Users/johnkerl/mini-corpus/tiledb-data/tabula-sapiens-epithelial')
for e in soma.obsm:
    print('obsm/'+e.name, e.shape(), e.uri)
for e in soma.varm:
    print('varm/'+e.name, e.shape(), e.uri)
for e in soma.obsp:
    print('obsp/'+e.name, e.shape(), e.uri)
for e in soma.varp:
    print('varp/'+e.name, e.shape(), e.uri)
```

```
obsm/X_scvi_umap (104148, 2) file:///Users/johnkerl/mini-corpus/tiledb-data/tabula-sapiens-epithelial/obsm/X_scvi_umap
obsm/X_scvi (104148, 50) file:///Users/johnkerl/mini-corpus/tiledb-data/tabula-sapiens-epithelial/obsm/X_scvi
obsm/X_pca (104148, 50) file:///Users/johnkerl/mini-corpus/tiledb-data/tabula-sapiens-epithelial/obsm/X_pca
obsm/X_umap (104148, 2) file:///Users/johnkerl/mini-corpus/tiledb-data/tabula-sapiens-epithelial/obsm/X_umap
obsp/connectivities (2074862, 3) file:///Users/johnkerl/mini-corpus/tiledb-data/tabula-sapiens-epithelial/obsp/connectivities
obsp/distances (1458072, 3) file:///Users/johnkerl/mini-corpus/tiledb-data/tabula-sapiens-epithelial/obsp/distances
```

Context: #95