### PR TITLE
Depend on new TileDB-Py 0.15.1

### DIFF
--- a/apis/python/setup.cfg
+++ b/apis/python/setup.cfg
@@ -32,7 +32,7 @@ zip_safe = False
 # The numpy pin is to avoid
 # "ImportError: Numba needs NumPy 1.21 or less"
 install_requires =
-    tiledb>=0.14.5
+    tiledb>=0.15.1
     scipy
     numpy<1.22
     pandas


### PR DESCRIPTION
Following on https://github.com/TileDB-Inc/TileDB-Py/pull/1109

For existing checkouts: `pip install --upgrade tiledb`