### PR TITLE
Store to-be-queried obs/var columns as ASCII (workaround)

### DIFF
--- a/apis/python/src/tiledbsc/soma_options.py
+++ b/apis/python/src/tiledbsc/soma_options.py
@@ -1,3 +1,34 @@
+from typing import List, Dict
+
+# TODO: when UTF-8 attributes are queryable using TileDB-Py's QueryCondition API we can remove this.
+# Context: https://github.com/single-cell-data/TileDB-SingleCell/issues/99.
+default_col_names_to_store_as_ascii = {
+    "obs": [
+        "assay_ontology_term_id",
+        "sex_ontology_term_id",
+        "organism_ontology_term_id",
+        "disease_ontology_term_id",
+        "ethnicity_ontology_term_id",
+        "development_stage_ontology_term_id",
+        "cell_type_ontology_term_id",
+        "tissue_ontology_term_id",
+        "cell_type",
+        "assay",
+        "disease",
+        "organism",
+        "sex",
+        "tissue",
+        "ethnicity",
+        "development_stage",
+    ],
+    "var": [
+        "feature_biotype",
+        "feature_name",
+        "feature_reference",
+    ],
+}
+
+
 class SOMAOptions:
     """
     A place to put configuration options various users may wish to change.
@@ -14,6 +45,7 @@ class SOMAOptions:
     string_dim_zstd_level: int
     write_X_chunked_if_csr: bool
     goal_chunk_nnz: int
+    col_names_to_store_as_ascii: Dict[str, List[str]]
 
     def __init__(
         self,
@@ -25,6 +57,7 @@ class SOMAOptions:
         string_dim_zstd_level=22,  # https://github.com/single-cell-data/TileDB-SingleCell/issues/27
         write_X_chunked_if_csr=True,
         goal_chunk_nnz=10000000,
+        col_names_to_store_as_ascii=default_col_names_to_store_as_ascii,
     ):
         self.obs_extent = obs_extent
         self.var_extent = var_extent
@@ -34,3 +67,4 @@ class SOMAOptions:
         self.string_dim_zstd_level = string_dim_zstd_level
         self.write_X_chunked_if_csr = write_X_chunked_if_csr
         self.goal_chunk_nnz = goal_chunk_nnz
+        self.col_names_to_store_as_ascii = col_names_to_store_as_ascii

--- a/apis/python/tests/test_tiledbsc.py
+++ b/apis/python/tests/test_tiledbsc.py
@@ -69,6 +69,7 @@ def test_import_anndata(adata):
         df = A.df[:]
         assert df.columns.to_list() == orig.obs_keys()
     # TODO: the left-hand side is a list of b'...' and the right-hand side is a list of '...'.
+    # This is because (at of May 2022) tiledb string dims must be of type ASCII.
     # assert sorted(soma.obs.ids()) == sorted(list(orig.obs_names))
     assert sorted([e.decode("utf-8") for e in soma.obs.ids()]) == sorted(
         list(orig.obs_names)
@@ -79,6 +80,7 @@ def test_import_anndata(adata):
         df = A.df[:]
         assert df.columns.to_list() == orig.var_keys()
     # TODO: the left-hand side is a list of b'...' and the right-hand side is a list of '...'.
+    # This is because (at of May 2022) tiledb string dims must be of type ASCII.
     # assert sorted(soma.var.ids()) == sorted(list(orig.var_names))
     assert sorted([e.decode("utf-8") for e in soma.var.ids()]) == sorted(
         list(orig.var_names)


### PR DESCRIPTION
As discussed on #99, these columns are non-queryable -- a blocker for prototype/demo work on #95 et al. -- unless they're stored as ASCII.

This allows us to generate SOMA data for the prototype/demo timeframe.