### PR TITLE
Implement SOMA-level dimension-slicing

### DIFF
--- a/apis/python/src/tiledbsc/annotation_dataframe.py
+++ b/apis/python/src/tiledbsc/annotation_dataframe.py
@@ -66,6 +66,18 @@ class AnnotationDataFrame(TileDBArray):
         return self.get_attr_names()
 
     # ----------------------------------------------------------------
+    def dim_select(self, ids):  # TODO: re None
+        """
+        TODO
+        """
+        if ids is None:
+            with tiledb.open(self.uri) as A:  # TODO: with self.open
+                return A.df[:]
+        else:
+            with tiledb.open(self.uri) as A:  # TODO: with self.open
+                return A.df[ids]
+
+    # ----------------------------------------------------------------
     def from_dataframe(self, dataframe: pd.DataFrame, extent: int) -> None:
         """
         Populates the obs/ or var/ subgroup for a SOMA object.

--- a/apis/python/src/tiledbsc/annotation_dataframe.py
+++ b/apis/python/src/tiledbsc/annotation_dataframe.py
@@ -66,9 +66,10 @@ class AnnotationDataFrame(TileDBArray):
         return self.get_attr_names()
 
     # ----------------------------------------------------------------
-    def dim_select(self, ids):  # TODO: re None
+    def dim_select(self, ids):
         """
-        TODO
+        Selects a slice out of the dataframe with specified `obs_ids` (for `obs`) or `var_ids` (for `var`).
+        If `ids` is `None`, the entire dataframe is returned.
         """
         if ids is None:
             with tiledb.open(self.uri) as A:  # TODO: with self.open

--- a/apis/python/src/tiledbsc/annotation_matrix.py
+++ b/apis/python/src/tiledbsc/annotation_matrix.py
@@ -31,6 +31,34 @@ class AnnotationMatrix(TileDBArray):
         self.dim_name = dim_name
 
     # ----------------------------------------------------------------
+    def dim_select(self, ids):  # TODO: re None
+        """
+        TODO
+        """
+        if ids is None:
+            with tiledb.open(self.uri) as A:  # TODO: with self.open
+                return A.df[:]
+        else:
+            with tiledb.open(self.uri) as A:  # TODO: with self.open
+                return A.df[ids]
+
+    # ----------------------------------------------------------------
+    def shape(self):
+        """
+        Returns a tuple with the number of rows and number of columns of the `AnnotationMatrix`.
+        The row-count is the number of obs_ids (for `obsm` elements) or the number of var_ids (for
+        `varm` elements).  The column-count is the number of columns/attributes in the dataframe.
+        """
+        with tiledb.open(self.uri) as A:  # TODO: with self.open
+            # These TileDB arrays are string-dimensioned sparse arrays so there is no '.shape'.
+            # Instead we compute it ourselves.  See also:
+            # * https://github.com/single-cell-data/TileDB-SingleCell/issues/10
+            # * https://github.com/TileDB-Inc/TileDB-Py/pull/1055
+            num_rows = len(A[:][self.dim_name].tolist())
+            num_cols = A.schema.nattr
+            return (num_rows, num_cols)
+
+    # ----------------------------------------------------------------
     def from_anndata(self, matrix, dim_values):
         """
         Populates an array in the obsm/ or varm/ subgroup for a SOMA object.
@@ -50,22 +78,6 @@ class AnnotationMatrix(TileDBArray):
 
         if self.verbose:
             print(util.format_elapsed(s, f"{self.indent}FINISH WRITING {self.uri}"))
-
-    # ----------------------------------------------------------------
-    def shape(self):
-        """
-        Returns a tuple with the number of rows and number of columns of the `AnnotationMatrix`.
-        The row-count is the number of obs_ids (for `obsm` elements) or the number of var_ids (for
-        `varm` elements).  The column-count is the number of columns/attributes in the dataframe.
-        """
-        with tiledb.open(self.uri) as A:  # TODO: with self.open
-            # These TileDB arrays are string-dimensioned sparse arrays so there is no '.shape'.
-            # Instead we compute it ourselves.  See also:
-            # * https://github.com/single-cell-data/TileDB-SingleCell/issues/10
-            # * https://github.com/TileDB-Inc/TileDB-Py/pull/1055
-            num_rows = len(A[:][self.dim_name].tolist())
-            num_cols = A.schema.nattr
-            return (num_rows, num_cols)
 
     # ----------------------------------------------------------------
     def _numpy_ndarray_or_scipy_sparse_csr_matrix(self, matrix, dim_values):

--- a/apis/python/src/tiledbsc/annotation_matrix.py
+++ b/apis/python/src/tiledbsc/annotation_matrix.py
@@ -31,9 +31,10 @@ class AnnotationMatrix(TileDBArray):
         self.dim_name = dim_name
 
     # ----------------------------------------------------------------
-    def dim_select(self, ids):  # TODO: re None
+    def dim_select(self, ids):
         """
-        TODO
+        Selects a slice out of the array with specified `obs_ids` (for `obsm` elements) or
+        `var_ids` (for `varm` elements).  If `ids` is `None`, the entire array is returned.
         """
         if ids is None:
             with tiledb.open(self.uri) as A:  # TODO: with self.open

--- a/apis/python/src/tiledbsc/annotation_pairwise_matrix.py
+++ b/apis/python/src/tiledbsc/annotation_pairwise_matrix.py
@@ -48,9 +48,10 @@ class AnnotationPairwiseMatrix(TileDBArray):
             return A.df[:].shape  # nnz x 3 -- id_i, id_j, and value
 
     # ----------------------------------------------------------------
-    def dim_select(self, ids):  # TODO: re None
+    def dim_select(self, ids):
         """
-        TODO
+        Selects a slice out of the array with specified `obs_ids` (for `obsp` elements) or
+        `var_ids` (for `varp` elements).  If `ids` is `None`, the entire array is returned.
         """
         if ids is None:
             with tiledb.open(self.uri) as A:  # TODO: with self.open

--- a/apis/python/src/tiledbsc/annotation_pairwise_matrix.py
+++ b/apis/python/src/tiledbsc/annotation_pairwise_matrix.py
@@ -48,6 +48,18 @@ class AnnotationPairwiseMatrix(TileDBArray):
             return A.df[:].shape  # nnz x 3 -- id_i, id_j, and value
 
     # ----------------------------------------------------------------
+    def dim_select(self, ids):  # TODO: re None
+        """
+        TODO
+        """
+        if ids is None:
+            with tiledb.open(self.uri) as A:  # TODO: with self.open
+                return A.df[:, :]
+        else:
+            with tiledb.open(self.uri) as A:  # TODO: with self.open
+                return A.df[ids, ids]
+
+    # ----------------------------------------------------------------
     def from_anndata(self, matrix, dim_values):
         """
         Populates an array in the obsp/ or varp/ subgroup for a SOMA object.

--- a/apis/python/src/tiledbsc/assay_matrix.py
+++ b/apis/python/src/tiledbsc/assay_matrix.py
@@ -45,6 +45,22 @@ class AssayMatrix(TileDBArray):
     # instead use the row-counts for the soma's obs and var.
 
     # ----------------------------------------------------------------
+    def dim_select(self, obs_ids, var_ids):  # TODO: maybe one is None
+        """
+        TODO
+        """
+        assert obs_ids != None or var_ids != None  # TODO: elaborate
+        if var_ids == None:
+            with tiledb.open(self.uri) as A:  # TODO: with self.open
+                return A.df[obs_ids, :]
+        elif obs_ids == None:
+            with tiledb.open(self.uri) as A:  # TODO: with self.open
+                return A.df[:, var_ids]
+        else:
+            with tiledb.open(self.uri) as A:  # TODO: with self.open
+                return A.df[obs_ids, var_ids]
+
+    # ----------------------------------------------------------------
     def from_matrix(self, matrix, row_names, col_names) -> None:
         """
         Imports a matrix -- nominally scipy.sparse.csr_matrix or numpy.ndarray -- into a TileDB

--- a/apis/python/src/tiledbsc/assay_matrix.py
+++ b/apis/python/src/tiledbsc/assay_matrix.py
@@ -45,20 +45,23 @@ class AssayMatrix(TileDBArray):
     # instead use the row-counts for the soma's obs and var.
 
     # ----------------------------------------------------------------
-    def dim_select(self, obs_ids, var_ids):  # TODO: maybe one is None
+    def dim_select(self, obs_ids, var_ids):
         """
-        TODO
+        Selects a slice out of the matrix with specified `obs_ids` and/or `var_ids`.
+        Either or both of the ID lists may be `None`, meaning, do not subselect along
+        that dimension. If both ID lists are `None`, the entire matrix is returned.
         """
-        assert obs_ids != None or var_ids != None  # TODO: elaborate
-        if var_ids == None:
-            with tiledb.open(self.uri) as A:  # TODO: with self.open
-                return A.df[obs_ids, :]
-        elif obs_ids == None:
-            with tiledb.open(self.uri) as A:  # TODO: with self.open
-                return A.df[:, var_ids]
-        else:
-            with tiledb.open(self.uri) as A:  # TODO: with self.open
-                return A.df[obs_ids, var_ids]
+        with tiledb.open(self.uri) as A:
+            if obs_ids is None:
+                if var_ids is None:
+                    return A.df[:, :]
+                else:
+                    return A.df[:, var_ids]
+            else:
+                if var_ids is None:
+                    return A.df[obs_ids, :]
+                else:
+                    return A.df[obs_ids, var_ids]
 
     # ----------------------------------------------------------------
     def from_matrix(self, matrix, row_names, col_names) -> None:

--- a/apis/python/src/tiledbsc/soma.py
+++ b/apis/python/src/tiledbsc/soma.py
@@ -125,50 +125,6 @@ class SOMA(TileDBGroup):
         return f"name={self.name},uri={self.uri}"
 
     # ----------------------------------------------------------------
-    def dim_select(
-        self,
-        slice_obs_ids,  # TODO: None means all ...
-        slice_var_ids,  # TODO: None means all ...
-    ) -> Dict:  # XXX TEMP
-        """
-        TODO
-        """
-
-        assert slice_obs_ids != None or slice_var_ids != None
-
-        if slice_obs_ids is None:
-            # Try the var slice first to see if that produces zero results -- if so we don't need to
-            # load the obs.
-            slice_var_df = self.var.dim_select(slice_var_ids)
-            if slice_var_df.shape[0] == 0:  # TODO: comment
-                return None
-            slice_obs_df = self.obs.dim_select(slice_obs_ids)
-            if slice_obs_df.shape[0] == 0:  # TODO: comment
-                return None
-
-        elif slice_var_ids is None:
-            # Try the obs slice first to see if that produces zero results -- if so we don't need to
-            # load the var.
-            slice_obs_df = self.obs.dim_select(slice_obs_ids)
-            if slice_obs_df.shape[0] == 0:  # TODO: comment
-                return None
-            slice_var_df = self.var.dim_select(slice_var_ids)
-            if slice_var_df.shape[0] == 0:  # TODO: comment
-                return None
-
-        else:
-            slice_obs_df = self.obs.dim_select(slice_obs_ids)
-            if slice_obs_df.shape[0] == 0:  # TODO: comment
-                return None
-            slice_var_df = self.var.dim_select(slice_var_ids)
-            if slice_var_df.shape[0] == 0:  # TODO: comment
-                return None
-
-        return self._assemble_soma_slice(
-            slice_obs_ids, slice_var_ids, slice_obs_df, slice_var_df
-        )
-
-    # ----------------------------------------------------------------
     def from_h5ad(self, input_path: str):
         """
         Reads an .h5ad file and writes to a TileDB group structure.

--- a/apis/python/src/tiledbsc/soma.py
+++ b/apis/python/src/tiledbsc/soma.py
@@ -125,6 +125,50 @@ class SOMA(TileDBGroup):
         return f"name={self.name},uri={self.uri}"
 
     # ----------------------------------------------------------------
+    def dim_select(
+        self,
+        slice_obs_ids,  # TODO: None means all ...
+        slice_var_ids,  # TODO: None means all ...
+    ) -> Dict:  # XXX TEMP
+        """
+        TODO
+        """
+
+        assert slice_obs_ids != None or slice_var_ids != None
+
+        if slice_obs_ids is None:
+            # Try the var slice first to see if that produces zero results -- if so we don't need to
+            # load the obs.
+            slice_var_df = self.var.dim_select(slice_var_ids)
+            if slice_var_df.shape[0] == 0:  # TODO: comment
+                return None
+            slice_obs_df = self.obs.dim_select(slice_obs_ids)
+            if slice_obs_df.shape[0] == 0:  # TODO: comment
+                return None
+
+        elif slice_var_ids is None:
+            # Try the obs slice first to see if that produces zero results -- if so we don't need to
+            # load the var.
+            slice_obs_df = self.obs.dim_select(slice_obs_ids)
+            if slice_obs_df.shape[0] == 0:  # TODO: comment
+                return None
+            slice_var_df = self.var.dim_select(slice_var_ids)
+            if slice_var_df.shape[0] == 0:  # TODO: comment
+                return None
+
+        else:
+            slice_obs_df = self.obs.dim_select(slice_obs_ids)
+            if slice_obs_df.shape[0] == 0:  # TODO: comment
+                return None
+            slice_var_df = self.var.dim_select(slice_var_ids)
+            if slice_var_df.shape[0] == 0:  # TODO: comment
+                return None
+
+        return self._assemble_soma_slice(
+            slice_obs_ids, slice_var_ids, slice_obs_df, slice_var_df
+        )
+
+    # ----------------------------------------------------------------
     def from_h5ad(self, input_path: str):
         """
         Reads an .h5ad file and writes to a TileDB group structure.

--- a/apis/python/tests/test_dim_select.py
+++ b/apis/python/tests/test_dim_select.py
@@ -1,0 +1,170 @@
+import anndata
+import tiledb
+import tiledbsc
+
+import pytest
+import tempfile
+import os
+from pathlib import Path
+
+HERE = Path(__file__).parent
+
+
+@pytest.fixture
+def h5ad_file(request):
+    # Tests in this file rely on specific values form this particular input data file.
+    input_path = HERE.parent / "anndata/pbmc-small.h5ad"
+    return input_path
+
+
+@pytest.fixture
+def adata(h5ad_file):
+    return anndata.read_h5ad(h5ad_file)
+
+
+def test_dim_select(adata):
+
+    # Set up anndata input path and tiledb-group output path
+    tempdir = tempfile.TemporaryDirectory()
+    output_path = tempdir.name
+
+    # Ingest
+    soma = tiledbsc.SOMA(output_path, verbose=True)
+    soma.from_anndata(adata)
+
+    assert soma.obs.ids() == [
+        b"AAATTCGAATCACG",
+        b"AAGCAAGAGCTTAG",
+        b"AAGCGACTTTGACG",
+        b"AATGCGTGGACGGA",
+        b"AATGTTGACAGTCA",
+        b"ACAGGTACTGGTGT",
+        b"ACCAGTGAATACCG",
+        b"ACGTGATGCCATGA",
+        b"ACTCGCACGAAAGT",
+        b"AGAGATGATCTCGC",
+        b"AGATATACCCGTAA",
+        b"AGGTCATGAGTGTC",
+        b"AGTCAGACTGCACA",
+        b"AGTCTTACTTCGGA",
+        b"ATAAGTTGGTACGT",
+        b"ATACCACTCTAAGC",
+        b"ATAGGAGAAACAGA",
+        b"ATCATCTGACACCA",
+        b"ATGCCAGAACGACT",
+        b"ATTACCTGCCTTAT",
+        b"ATTCAGCTCATTGG",
+        b"ATTGCACTTGCTTT",
+        b"ATTGTAGATTCCCG",
+        b"CATATAGACTAAGC",
+        b"CATCAGGATGCACA",
+        b"CATCATACGGAGCA",
+        b"CATGAGACACGGGA",
+        b"CATGCGCTAGTCAC",
+        b"CATGGCCTGTGCAT",
+        b"CATTACACCAACTG",
+        b"CCATCCGATTCGCC",
+        b"CCCAACTGCAATCG",
+        b"CCTATAACGAGACG",
+        b"CGGCACGAACTCAG",
+        b"CGTAGCCTGTATGC",
+        b"CTAAACCTCTGACA",
+        b"CTAAACCTGTGCAT",
+        b"CTAACGGAACCGAT",
+        b"CTAGGTGATGGTTG",
+        b"CTGCCAACAGGAGC",
+        b"CTTCATGACCGAAT",
+        b"CTTGATTGATCTTC",
+        b"GAACCTGATGAACC",
+        b"GACATTCTCCACCT",
+        b"GACGCTCTCTCTCG",
+        b"GAGTTGTGGTAGCT",
+        b"GATAGAGAAGGGTG",
+        b"GATAGAGATCACGA",
+        b"GATATAACACGCAT",
+        b"GCACTAGACCTTTA",
+        b"GCAGCTCTGTTTCT",
+        b"GCGCACGACTTTAC",
+        b"GCGCATCTTGCTCC",
+        b"GCGTAAACACGGTT",
+        b"GCTCCATGAGAAGT",
+        b"GGAACACTTCAGAC",
+        b"GGCATATGCTTATC",
+        b"GGCATATGGGGAGT",
+        b"GGCCGATGTACTCT",
+        b"GGGTAACTCTAGTG",
+        b"GGTGGAGATTACTC",
+        b"GTAAGCACTCATTC",
+        b"GTCATACTTCGCCT",
+        b"GTTGACGATATCGG",
+        b"TACAATGATGCTAG",
+        b"TACATCACGCTAAC",
+        b"TACGCCACTCCGAA",
+        b"TACTCTGAATCGAC",
+        b"TAGGGACTGAACTC",
+        b"TCCACTCTGAGCTT",
+        b"TCTGATACACGTGT",
+        b"TGACTGGATTCTCA",
+        b"TGAGCTGAATGCTG",
+        b"TGGTATCTAAACAG",
+        b"TTACCATGAATCGC",
+        b"TTACGTACGTTCAG",
+        b"TTGAGGACTACGCA",
+        b"TTGCATTGAGCTAC",
+        b"TTGGTACTGAATCC",
+        b"TTTAGCTGTACTCT",
+    ]
+
+    assert soma.var.ids() == [
+        b"AKR1C3",
+        b"CA2",
+        b"CD1C",
+        b"GNLY",
+        b"HLA-DPB1",
+        b"HLA-DQA1",
+        b"IGLL5",
+        b"MYL9",
+        b"PARVB",
+        b"PF4",
+        b"PGRMC1",
+        b"PPBP",
+        b"RP11-290F20.3",
+        b"RUFY1",
+        b"S100A8",
+        b"S100A9",
+        b"SDPR",
+        b"TREML1",
+        b"TUBB1",
+        b"VDAC3",
+    ]
+
+    df = soma.obs.dim_select([b"AAGCGACTTTGACG", b"AATGCGTGGACGGA"])
+    assert df.shape == (2, 7)
+    assert df.at["AAGCGACTTTGACG", "groups"] == "g1"
+    assert df.at["AATGCGTGGACGGA", "nFeature_RNA"] == 73
+    #                 orig.ident  nCount_RNA  nFeature_RNA  RNA_snn_res.0.8  letter.idents groups  RNA_snn_res.1
+    # obs_id
+    # AAGCGACTTTGACG           0       443.0            77                1              1     g1              1
+    # AATGCGTGGACGGA           0       389.0            73                1              1     g1              1
+    assert soma.obs.dim_select(None).shape == (80, 7)
+
+    df = soma.var.dim_select([b"AKR1C3", b"MYL9"])
+    assert df.shape == (2, 5)
+    assert df.at["AKR1C3", "vst.variable"] == 1
+    assert df.at["MYL9", "vst.variable"] == 1
+    assert soma.var.dim_select(None).shape == (20, 5)
+
+    assert sorted(soma.obsm.keys()) == sorted(["X_tsne", "X_pca"])
+
+    df = soma.obsm["X_tsne"].dim_select([b"AAGCGACTTTGACG", b"AATGCGTGGACGGA"])
+    assert df.shape == (2, 3)
+
+    df = soma.obsm["X_pca"].dim_select([b"AAGCGACTTTGACG", b"AATGCGTGGACGGA"])
+    assert df.shape == (2, 20)
+
+    assert soma.X.data.dim_select([b"AAGCGACTTTGACG"], [b"AKR1C3"]).shape == (1, 3)
+    assert soma.X.data.dim_select(None, [b"AKR1C3"]).shape == (80, 3)
+    assert soma.X.data.dim_select([b"AAGCGACTTTGACG"], None).shape == (20, 3)
+    assert soma.X.data.dim_select(None, None).shape == (1600, 3)
+
+    tempdir.cleanup()


### PR DESCRIPTION
Context: #95 

Examples (see also test cases on this PR):

```
$ ./tools/ingestor anndata/pbmc-small.h5ad ./tiledb-data/pbmc-small
...
```

```
>>> import tiledbsc

>>> soma = tiledbsc.SOMA('./tiledb-data/pbmc-small')

>>> soma.obs.ids()
[b'AAATTCGAATCACG', b'AAGCAAGAGCTTAG', b'AAGCGACTTTGACG', b'AATGCGTGGACGGA', [snip] b'TTGCATTGAGCTAC', b'TTGGTACTGAATCC', b'TTTAGCTGTACTCT']

>>> soma.var.ids()
[b'AKR1C3', b'CA2', b'CD1C', b'GNLY', b'HLA-DPB1', b'HLA-DQA1', b'IGLL5', b'MYL9', b'PARVB', b'PF4', b'PGRMC1', b'PPBP', b'RP11-290F20.3', b'RUFY1', b'S100A8', b'S100A9', b'SDPR', b'TREML1', b'TUBB1', b'VDAC3']

>>> soma.obs.dim_select([b'AAGCGACTTTGACG', b'AATGCGTGGACGGA'])
                orig.ident  nCount_RNA  nFeature_RNA  RNA_snn_res.0.8  letter.idents groups  RNA_snn_res.1
obs_id
AAGCGACTTTGACG           0       443.0            77                1              1     g1              1
AATGCGTGGACGGA           0       389.0            73                1              1     g1              1

>>> soma.var.dim_select([b'AKR1C3', b'MYL9'])
        vst.mean  vst.variance  vst.variance.expected  vst.variance.standardized  vst.variable
var_id
AKR1C3    0.2625      1.132753               0.553424                   2.021191             1
MYL9      0.2875      1.321361               0.614125                   1.938228             1

>>> soma.obsm.keys()
['X_tsne', 'X_pca']

>>> soma.obsm['X_tsne'].dim_select([b'AAGCGACTTTGACG', b'AATGCGTGGACGGA'])
           obs_id   X_tsne_1   X_tsne_2
0  AAGCGACTTTGACG -31.919623  -0.864304
1  AATGCGTGGACGGA  -1.839384  22.204006

>>> soma.obsm['X_pca'].dim_select([b'AAGCGACTTTGACG', b'AATGCGTGGACGGA'])
           obs_id   X_pca_1   X_pca_2   X_pca_3   X_pca_4  ...  X_pca_15  X_pca_16  X_pca_17  X_pca_18  X_pca_19
0  AAGCGACTTTGACG -1.380380  1.284101  1.918055  1.247647  ...  0.117602  0.169661  0.130810 -0.041855  0.027550
1  AATGCGTGGACGGA -1.494413  1.783583  0.661433 -0.584200  ... -0.163601 -0.082049 -0.145453 -0.045108  0.055206

[2 rows x 20 columns]

>>> soma.X.data.dim_select([b'AAGCGACTTTGACG'], [b'AKR1C3'])
           obs_id  var_id     value
0  AAGCGACTTTGACG  AKR1C3 -0.325888

>>> soma.X.data.dim_select([b'AAGCGACTTTGACG'], None)
            obs_id         var_id     value
0   AAGCGACTTTGACG         AKR1C3 -0.325888
1   AAGCGACTTTGACG            CA2 -0.346938
2   AAGCGACTTTGACG           CD1C -0.253005
3   AAGCGACTTTGACG           GNLY -0.528670
4   AAGCGACTTTGACG       HLA-DPB1  0.412720
5   AAGCGACTTTGACG       HLA-DQA1 -0.671707
6   AAGCGACTTTGACG          IGLL5 -0.193495
7   AAGCGACTTTGACG           MYL9 -0.301435
8   AAGCGACTTTGACG          PARVB -0.346179
9   AAGCGACTTTGACG            PF4 -0.370707
10  AAGCGACTTTGACG         PGRMC1 -0.329147
11  AAGCGACTTTGACG           PPBP -0.422769
12  AAGCGACTTTGACG  RP11-290F20.3  2.782381
13  AAGCGACTTTGACG          RUFY1 -0.409833
14  AAGCGACTTTGACG         S100A8  1.007046
15  AAGCGACTTTGACG         S100A9  1.127458
16  AAGCGACTTTGACG           SDPR -0.388176
17  AAGCGACTTTGACG         TREML1 -0.328625
18  AAGCGACTTTGACG          TUBB1 -0.350375
19  AAGCGACTTTGACG          VDAC3 -0.524551

>>> soma.X.data.dim_select(None, [b'AKR1C3'])
            obs_id  var_id     value
0   AAATTCGAATCACG  AKR1C3 -0.325888
1   AAGCAAGAGCTTAG  AKR1C3 -0.325888
2   AAGCGACTTTGACG  AKR1C3 -0.325888
3   AATGCGTGGACGGA  AKR1C3 -0.325888
4   AATGTTGACAGTCA  AKR1C3 -0.325888
..             ...     ...       ...
75  TTACGTACGTTCAG  AKR1C3 -0.325888
76  TTGAGGACTACGCA  AKR1C3 -0.325888
77  TTGCATTGAGCTAC  AKR1C3 -0.325888
78  TTGGTACTGAATCC  AKR1C3 -0.325888
79  TTTAGCTGTACTCT  AKR1C3 -0.325888

[80 rows x 3 columns]
```