### PR TITLE
Attribute-filter logic for obs and var

### DIFF
--- a/apis/python/src/tiledbsc/annotation_dataframe.py
+++ b/apis/python/src/tiledbsc/annotation_dataframe.py
@@ -79,10 +79,12 @@ class AnnotationDataFrame(TileDBArray):
                 return A.df[ids]
 
     # ----------------------------------------------------------------
+    # TODO: this is a v1 for prototype/demo timeframe -- needs expanding.
     def attribute_filter(self, query_string, col_names_to_keep):
         """
         Selects from obs/var using a TileDB-Py `QueryCondition` string such as
         'cell_type == "blood"'. Returns None if the slice is empty.
+        This is a v1 implementation for the prototype/demo timeframe.
         """
         with tiledb.open(self.uri) as A:
             qc = tiledb.QueryCondition(query_string)

--- a/apis/python/src/tiledbsc/annotation_dataframe.py
+++ b/apis/python/src/tiledbsc/annotation_dataframe.py
@@ -79,6 +79,22 @@ class AnnotationDataFrame(TileDBArray):
                 return A.df[ids]
 
     # ----------------------------------------------------------------
+    def attribute_filter(self, query_string, col_names_to_keep):
+        """
+        Selects from obs/var using a TileDB-Py `QueryCondition` string such as
+        'cell_type == "blood"'. Returns None if the slice is empty.
+        """
+        with tiledb.open(self.uri) as A:
+            qc = tiledb.QueryCondition(query_string)
+            slice_query = A.query(attr_cond=qc)
+            slice_df = slice_query.df[:][col_names_to_keep]
+            nobs = len(slice_df)
+            if nobs == 0:
+                return None
+            else:
+                return slice_df
+
+    # ----------------------------------------------------------------
     def from_dataframe(self, dataframe: pd.DataFrame, extent: int) -> None:
         """
         Populates the obs/ or var/ subgroup for a SOMA object.

--- a/apis/python/src/tiledbsc/soma.py
+++ b/apis/python/src/tiledbsc/soma.py
@@ -319,6 +319,7 @@ class SOMA(TileDBGroup):
     def _to_anndata(self) -> ad.AnnData:
         """
         Internal helper function for to_anndata; same arguments.
+        Note: obsp/varp outgest is omitted at present, pending some issues.
         """
 
         obs_df = self.obs.to_dataframe()

--- a/apis/python/tests/test_attribute_filter.py
+++ b/apis/python/tests/test_attribute_filter.py
@@ -1,0 +1,73 @@
+import anndata
+import tiledb
+import tiledbsc
+
+import pytest
+import tempfile
+import os
+from pathlib import Path
+
+HERE = Path(__file__).parent
+
+
+@pytest.fixture
+def h5ad_file(request):
+    # Tests in this file rely on specific values form this particular input data file.
+    input_path = HERE.parent / "anndata/pbmc-small.h5ad"
+    return input_path
+
+
+@pytest.fixture
+def adata(h5ad_file):
+    return anndata.read_h5ad(h5ad_file)
+
+
+def test_attribute_filter(adata):
+
+    # Set up anndata input path and tiledb-group output path
+    tempdir = tempfile.TemporaryDirectory()
+    output_path = tempdir.name
+
+    # Ingest
+    soma = tiledbsc.SOMA(output_path, verbose=True)
+    soma.from_anndata(adata)
+
+    output = soma.obs.attribute_filter(
+        "nCount_RNA > 10", ["orig.ident", "nFeature_RNA"]
+    )
+    assert output.shape == (80, 2)
+    assert output.at["TTACGTACGTTCAG", "nFeature_RNA"] == 39
+    #                 orig.ident  nFeature_RNA
+    # obs_id
+    # AAATTCGAATCACG           0            62
+    # AAGCAAGAGCTTAG           0            48
+    # AAGCGACTTTGACG           0            77
+    # AATGCGTGGACGGA           0            73
+    # AATGTTGACAGTCA           0            41
+    # ...                    ...           ...
+    # TTACGTACGTTCAG           0            39
+    # TTGAGGACTACGCA           0            88
+    # TTGCATTGAGCTAC           0            40
+    # TTGGTACTGAATCC           0            45
+    # TTTAGCTGTACTCT           0            86
+
+    # Note: attribute names with "." in them need to be written like 'attr("this.has.dots")' within
+    # query-condition expressions.
+    output = soma.var.attribute_filter(
+        'attr("vst.mean") > 1', ["vst.mean", "vst.variance", "vst.variable"]
+    )
+    assert output.shape == (9, 3)
+    assert output.at["S100A8", "vst.variable"] == 1
+    #           vst.mean  vst.variance  vst.variance.expected  vst.variance.standardized  vst.variable
+    # var_id
+    # GNLY        2.4000     43.762025              24.078566                   1.817468             1
+    # HLA-DPB1    7.6500    309.800000             199.154430                   1.555577             1
+    # HLA-DQA1    1.9875     32.164399              19.810998                   1.623563             1
+    # PF4         2.1500     65.243038              21.482754                   1.939028             1
+    # PPBP        5.3250    231.817089              93.148559                   2.488681             1
+    # S100A8      2.9750     53.012025              32.261112                   1.643218             1
+    # S100A9      6.8375    240.644146             156.219313                   1.540425             1
+    # SDPR        1.1125     15.746677               8.835280                   1.680686             1
+    # VDAC3       1.1250     30.971519               8.986513                   2.137607             1
+
+    tempdir.cleanup()


### PR DESCRIPTION
Context: #95 

Examples:

```
>>> soma = tiledbsc.SOMA('/Users/johnkerl/mini-corpus/tiledb-data/tabula-sapiens-immune')
```

```
>>> soma.obs.attribute_filter('tissue == "blood"', ['development_stage'])
                                                         development_stage
obs_id
AAACCCAAGACCAAGC_TSP14_Blood_NA_10X_3_1            59-year-old human stage
AAACCCAAGCAACAGC_TSP1_blood_3                      59-year-old human stage
AAACCCAAGCACCAGA_TSP8_Blood_NA_10X_1_1             56-year-old human stage
AAACCCAAGCATCAAA_TSP2_Blood_NA_10X_1_3             61-year-old human stage
AAACCCAAGCCGTCGT_TSP7_Blood_NA_10X_1_1             69-year-old human stage
...                                                                    ...
TTTGTTGTCCTAAACG_TSP2_Blood_NA_10X_1_3             61-year-old human stage
TTTGTTGTCGATTGAC_TSP7_Blood_NA_10X_1_1             69-year-old human stage
TTTGTTGTCGCATTGA_TSP7_Blood_NA_10X_1_1             69-year-old human stage
TTTGTTGTCTAACGCA_TSP2_Blood_NA_10X_1_1_SheelaPrep  61-year-old human stage
TTTGTTGTCTTGAACG_TSP1_blood_3                      59-year-old human stage

[50115 rows x 1 columns]
```

```
>>> soma.var.attribute_filter('feature_name == "SCYL3"', ['feature_name','ensemblid'])
                feature_name           ensemblid
var_id
ENSG00000000457     b'SCYL3'  ENSG00000000457.14
>>>
```
