### PR TITLE
Allow correct relative-membership flags for local disk as well as TileDB Cloud [WIP]

### DIFF
--- a/apis/python/src/tiledbsc/soma_options.py
+++ b/apis/python/src/tiledbsc/soma_options.py
@@ -46,6 +46,7 @@ class SOMAOptions:
     write_X_chunked: bool
     goal_chunk_nnz: int
     col_names_to_store_as_ascii: Dict[str, List[str]]
+    member_uris_are_relative: bool
 
     def __init__(
         self,
@@ -58,6 +59,7 @@ class SOMAOptions:
         write_X_chunked=True,
         goal_chunk_nnz=10000000,
         col_names_to_store_as_ascii=default_col_names_to_store_as_ascii,
+        member_uris_are_relative=None,  # Allows relocatability for local disk / S3, and correct behavior for TileDB Cloud
     ):
         self.obs_extent = obs_extent
         self.var_extent = var_extent
@@ -68,3 +70,4 @@ class SOMAOptions:
         self.write_X_chunked = write_X_chunked
         self.goal_chunk_nnz = goal_chunk_nnz
         self.col_names_to_store_as_ascii = col_names_to_store_as_ascii
+        self.member_uris_are_relative = member_uris_are_relative

--- a/apis/python/src/tiledbsc/tiledb_group.py
+++ b/apis/python/src/tiledbsc/tiledb_group.py
@@ -116,7 +116,7 @@ class TileDBGroup(TileDBObject):
 
     def _remove_object(self, obj: TileDBObject):
         with self._open("w") as G:
-            G.remove(obj.uri)
+            G.remove(obj.name)
 
     def _get_member_names(self):
         """

--- a/apis/python/tests/test_soco_ops.py
+++ b/apis/python/tests/test_soco_ops.py
@@ -13,7 +13,7 @@ HERE = Path(__file__).parent
 def test_import_anndata(tmp_path):
 
     ann1 = HERE.parent / "anndata/pbmc-small.h5ad"
-    ann2 = HERE.parent / "anndata/pbmc3k_processed.h5ad"
+    ann2 = HERE.parent / "anndata/pbmc-small-x-csr.h5ad"
 
     soco_dir = tmp_path.as_posix()
     soma1_dir = (tmp_path / "soma1").as_posix()

--- a/apis/python/tools/README.md
+++ b/apis/python/tools/README.md
@@ -1,2 +1,2 @@
 Scripts in this directory are keystroke-savers for using the SOMA API.  They also offer some example
-use of the API -- although there will be an `examples` directory dedicated to the latter purpose.
+uses of the API -- although there will be an `examples` directory dedicated to the latter purpose.

--- a/apis/python/tools/ingestor
+++ b/apis/python/tools/ingestor
@@ -38,6 +38,23 @@ def main():
         type=str,
         default="./tiledb-data",
     )
+    parser.add_argument(
+        "-r", "--relative",
+        help=
+"""
+* If `false` then the group will remember the absolute paths of each member array/subgroup. For
+ingesting to TileDB Cloud, this is necessary.
+
+* If `true` then the group will have the relative pth of the member. For TileDB Cloud, this
+is never the right thing to do. For local-disk storage, this is essential if you want to move
+a SOMA to another directory and have it be able access its members.
+
+* If `auto`, then we select `relative=False` if the URI starts with `tiledb://`, else we
+select `relative=True`. (This is the default.)
+""",
+        choices=["true", "false", "auto"],
+        nargs=1,
+    )
     # TODO: add an update option once we figure out tiledb.from_pandas mode=overwrite flag.
     parser.add_argument(
         "--ifexists",
@@ -57,9 +74,19 @@ def main():
     if args.ifexists is None:
         args.ifexists = ["continue"]
 
-    outdir = args.o.rstrip("/")
+    soma_options = tiledbsc.SOMAOptions()
 
     verbose = not args.quiet
+
+    if args.relative == 'true':
+        soma_options.relative_membership = True
+    elif args.relative == 'false':
+        soma_options.relative_membership = False
+    elif args.relative == 'auto':
+        soma_options.relative_membership = None
+    # No else -- we only allowed those three choices in the argument-parser.
+
+    outdir = args.o.rstrip("/")
 
     if args.n:
         if len(args.paths) < 1:
@@ -70,29 +97,29 @@ def main():
             output_path = os.path.join(
                 outdir, os.path.splitext(os.path.basename(input_path))[0]
             )
-            ingest_one(input_path, output_path, args.ifexists[0], verbose)
+            ingest_one(input_path, output_path, args.ifexists[0], soma_options, verbose)
     else:
         if len(args.paths) == 0:
             input_path = "anndata/pbmc-small.h5ad"
             output_path = os.path.join(outdir, "pbmc-small")
-            ingest_one(input_path, output_path, args.ifexists[0], verbose)
+            ingest_one(input_path, output_path, args.ifexists[0], soma_options, verbose)
         elif len(args.paths) == 1:
             input_path = args.paths[0]
             # Example 'anndata/pbmc3k_processed.h5ad' -> 'tiledb-data/pbmc3k_processed'
             output_path = os.path.join(
                 outdir, os.path.splitext(os.path.basename(input_path))[0]
             )
-            ingest_one(input_path, output_path, args.ifexists[0], verbose)
+            ingest_one(input_path, output_path, args.ifexists[0], soma_options, verbose)
         elif len(args.paths) == 2:
             input_path = args.paths[0]
             output_path = args.paths[1]
-            ingest_one(input_path, output_path, args.ifexists[0], verbose)
+            ingest_one(input_path, output_path, args.ifexists[0], soma_options, verbose)
         else:
             parser.print_help(file=sys.stderr)
             sys.exit(1)
 
 
-def ingest_one(input_path: str, output_path: str, ifexists: str, verbose: bool):
+def ingest_one(input_path: str, output_path: str, ifexists: str, soma_options: tiledbsc.SOMAOptions, verbose: bool):
     # Check that the input exists.
     if not os.path.exists(input_path):
         # Print this neatly and exit neatly, to avoid a multi-line stack trace otherwise.
@@ -103,8 +130,9 @@ def ingest_one(input_path: str, output_path: str, ifexists: str, verbose: bool):
     # This is for local-disk use only -- for S3-backed tiledb://... URIs we should
     # use tiledb.vfs to remove any priors, and/or make use of a tiledb `overwrite` flag.
     parent = os.path.dirname(output_path.rstrip("/"))
-    if not os.path.exists(parent):
-        os.mkdir(parent)
+    if parent != "":
+        if not os.path.exists(parent):
+            os.mkdir(parent)
 
     if os.path.exists(output_path):
         if ifexists == "continue":
@@ -121,7 +149,7 @@ def ingest_one(input_path: str, output_path: str, ifexists: str, verbose: bool):
                 "Internal coding error in --ifexists handling.", ifexists, "<"
             )
 
-    soma = tiledbsc.SOMA(uri=output_path, verbose=verbose)
+    soma = tiledbsc.SOMA(uri=output_path, soma_options=soma_options)
 
     # Do the ingest into TileDB.
     soma.from_h5ad(input_path)


### PR DESCRIPTION
The `relative` flag, which we set correctly for TileDB Cloud ops, is not desirable for local-disk or S3 operations within a SOMA. For pre-demo experiments, creating a little mini-collection of SOMAs and moving them around, this is a bit annoying -- @ebezzi and I have both bumped into this.

# Before

```
$ ingestor --ifexists replace anndata/pbmc-small.h5ad
...
```

```
$ peek-soma tiledb-data/pbmc-small
>>> soma.obs.df()
                orig.ident  nCount_RNA  nFeature_RNA  RNA_snn_res.0.8  letter.idents groups  RNA_snn_res.1
obs_id
AAATTCGAATCACG           0       327.0            62                1              1     g2              1
AAGCAAGAGCTTAG           0       126.0            48                0              0     g1              0
AAGCGACTTTGACG           0       443.0            77                1              1     g1              1
AATGCGTGGACGGA           0       389.0            73                1              1     g1              1
AATGTTGACAGTCA           0       100.0            41                0              0     g1              0
...                    ...         ...           ...              ...            ...    ...            ...
TTACGTACGTTCAG           0       228.0            39                0              0     g1              0
TTGAGGACTACGCA           0       787.0            88                0              0     g1              2
TTGCATTGAGCTAC           0       104.0            40                0              0     g2              2
TTGGTACTGAATCC           0       135.0            45                0              0     g1              2
TTTAGCTGTACTCT           0       462.0            86                1              1     g1              1

[80 rows x 7 columns]
```

```
$ mv tiledb-data/pbmc-small .
```

```
$ peek-soma tiledb-data/pbmc-small
>>> soma.obs.df()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/johnkerl/git/single-cell-data/TileDB-SingleCell/apis/python/src/tiledbsc/annotation_dataframe.py", line 87, in df
    return self.dim_select(ids)
  File "/Users/johnkerl/git/single-cell-data/TileDB-SingleCell/apis/python/src/tiledbsc/annotation_dataframe.py", line 75, in dim_select
    with tiledb.open(self.uri) as A:  # TODO: with self.open
  File "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/tiledb/highlevel.py", line 23, in open
    return tiledb.Array.load_typed(
  File "tiledb/libtiledb.pyx", line 3447, in tiledb.libtiledb.Array.load_typed
  File "tiledb/libtiledb.pyx", line 3273, in tiledb.libtiledb.preload_array
  File "tiledb/libtiledb.pyx", line 526, in tiledb.libtiledb._raise_ctx_err
  File "tiledb/libtiledb.pyx", line 511, in tiledb.libtiledb._raise_tiledb_error
tiledb.cc.TileDBError: [TileDB::Array] Error: Cannot open array; Array does not exist
```

# After

```
$ ingestor --ifexists replace --relative=auto anndata/pbmc-small.h5ad
...
```

```
$ peek-soma tiledb-data/pbmc-small
>>> soma.obs.df()
                orig.ident  nCount_RNA  nFeature_RNA  RNA_snn_res.0.8  letter.idents groups  RNA_snn_res.1
obs_id
AAATTCGAATCACG           0       327.0            62                1              1     g2              1
AAGCAAGAGCTTAG           0       126.0            48                0              0     g1              0
AAGCGACTTTGACG           0       443.0            77                1              1     g1              1
AATGCGTGGACGGA           0       389.0            73                1              1     g1              1
AATGTTGACAGTCA           0       100.0            41                0              0     g1              0
...                    ...         ...           ...              ...            ...    ...            ...
TTACGTACGTTCAG           0       228.0            39                0              0     g1              0
TTGAGGACTACGCA           0       787.0            88                0              0     g1              2
TTGCATTGAGCTAC           0       104.0            40                0              0     g2              2
TTGGTACTGAATCC           0       135.0            45                0              0     g1              2
TTTAGCTGTACTCT           0       462.0            86                1              1     g1              1

[80 rows x 7 columns]
```

```
$ rm -rvf ./tiledb-small
$ mv tiledb-data/pbmc-small .
```

```
$ peek-soma tiledb-data/pbmc-small
>>> soma.obs.df()
                orig.ident  nCount_RNA  nFeature_RNA  RNA_snn_res.0.8  letter.idents groups  RNA_snn_res.1
obs_id
AAATTCGAATCACG           0       327.0            62                1              1     g2              1
AAGCAAGAGCTTAG           0       126.0            48                0              0     g1              0
AAGCGACTTTGACG           0       443.0            77                1              1     g1              1
AATGCGTGGACGGA           0       389.0            73                1              1     g1              1
AATGTTGACAGTCA           0       100.0            41                0              0     g1              0
...                    ...         ...           ...              ...            ...    ...            ...
TTACGTACGTTCAG           0       228.0            39                0              0     g1              0
TTGAGGACTACGCA           0       787.0            88                0              0     g1              2
TTGCATTGAGCTAC           0       104.0            40                0              0     g2              2
TTGGTACTGAATCC           0       135.0            45                0              0     g1              2
TTTAGCTGTACTCT           0       462.0            86                1              1     g1              1
```
