### PR TITLE
Flag some for-internal-use methods more clearly as such

### DIFF
--- a/apis/python/README.md
+++ b/apis/python/README.md
@@ -248,7 +248,7 @@ VDAC3            1.1250     30.971519               8.986513                   2
 ```
 
 ```
->>> soma.obsm.get_member_names()
+>>> soma.obsm._get_member_names()
 ['X_tsne', 'X_pca']
 >>> arr = soma.obsm['X_pca'].open_array()
 >>> arr.df[:]
@@ -277,11 +277,11 @@ VDAC3            1.1250     30.971519               8.986513                   2
 ```
 
 ```
->>> soma.uns.get_member_names()
+>>> soma.uns._get_member_names()
 ['neighbors']
->>> soma.uns['neighbors'].get_member_names()
+>>> soma.uns['neighbors']._get_member_names()
 ['params']
->>> soma.uns['neighbors']['params'].get_member_names()
+>>> soma.uns['neighbors']['params']._get_member_names()
 ['method']
 >>> arr = soma.uns['neighbors']['params']['method'].open_array()
 >>> arr.df[:]

--- a/apis/python/src/tiledbsc/annotation_dataframe.py
+++ b/apis/python/src/tiledbsc/annotation_dataframe.py
@@ -38,7 +38,7 @@ class AnnotationDataFrame(TileDBArray):
         The row-count is the number of obs_ids (for `obs`) or the number of var_ids (for `var`).
         The column-count is the number of columns/attributes in the dataframe.
         """
-        # TODO: with self.open: see
+        # TODO: with self._open: see
         # https://github.com/single-cell-data/TileDB-SingleCell/pull/93
         with tiledb.open(self.uri) as A:
             # These TileDB arrays are string-dimensioned sparse arrays so there is no '.shape'.
@@ -72,10 +72,10 @@ class AnnotationDataFrame(TileDBArray):
         If `ids` is `None`, the entire dataframe is returned.
         """
         if ids is None:
-            with tiledb.open(self.uri) as A:  # TODO: with self.open
+            with tiledb.open(self.uri) as A:  # TODO: with self._open
                 return A.df[:]
         else:
-            with tiledb.open(self.uri) as A:  # TODO: with self.open
+            with tiledb.open(self.uri) as A:  # TODO: with self._open
                 return A.df[ids]
 
     # ----------------------------------------------------------------
@@ -119,9 +119,9 @@ class AnnotationDataFrame(TileDBArray):
         dim_filters = tiledb.FilterList([tiledb.ZstdFilter(level=-1)])
         attr_filters = tiledb.FilterList([tiledb.ZstdFilter(level=-1)])
 
-        if self.verbose:
+        if self._verbose:
             s = util.get_start_stamp()
-            print(f"{self.indent}START  WRITING {self.uri}")
+            print(f"{self._indent}START  WRITING {self.uri}")
 
         # Make the row-names column (barcodes for obs, gene names for var) explicitly named.
         # Otherwise it'll be called '__tiledb_rows'.
@@ -151,16 +151,16 @@ class AnnotationDataFrame(TileDBArray):
         mode = "ingest"
         if self.exists():
             mode = "append"
-            if self.verbose:
-                print(f"{self.indent}Re-using existing array {self.uri}")
+            if self._verbose:
+                print(f"{self._indent}Re-using existing array {self.uri}")
 
         # Context: https://github.com/single-cell-data/TileDB-SingleCell/issues/99.
         # TODO: when UTF-8 attributes are queryable using TileDB-Py's QueryCondition API we can remove this.
         column_types = {}  # XXX None OR {} ?
-        if self.name in self.soma_options.col_names_to_store_as_ascii:
-            col_names_to_store_as_ascii = self.soma_options.col_names_to_store_as_ascii[
-                self.name
-            ]
+        if self.name in self._soma_options.col_names_to_store_as_ascii:
+            col_names_to_store_as_ascii = (
+                self._soma_options.col_names_to_store_as_ascii[self.name]
+            )
             for col_name in col_names_to_store_as_ascii:
                 column_types[col_name] = np.dtype("S")
 
@@ -176,12 +176,12 @@ class AnnotationDataFrame(TileDBArray):
             capacity=100000,
             tile=extent,
             column_types=column_types,
-            ctx=self.ctx,
+            ctx=self._ctx,
             mode=mode,
         )
 
-        if self.verbose:
-            print(util.format_elapsed(s, f"{self.indent}FINISH WRITING {self.uri}"))
+        if self._verbose:
+            print(util.format_elapsed(s, f"{self._indent}FINISH WRITING {self.uri}"))
 
     # ----------------------------------------------------------------
     def to_dataframe(self) -> pd.DataFrame:
@@ -190,9 +190,9 @@ class AnnotationDataFrame(TileDBArray):
         and dimension values.
         """
 
-        if self.verbose:
+        if self._verbose:
             s = util.get_start_stamp()
-            print(f"{self.indent}START  read {self.uri}")
+            print(f"{self._indent}START  read {self.uri}")
 
         with tiledb.open(self.uri) as A:
             # We could use A.df[:] to set the index_name to 'obs_id' or 'var_id'.
@@ -201,7 +201,7 @@ class AnnotationDataFrame(TileDBArray):
             df = pd.DataFrame(A[:])
             df = df.set_index(self.dim_name)
 
-        if self.verbose:
-            print(util.format_elapsed(s, f"{self.indent}FINISH read {self.uri}"))
+        if self._verbose:
+            print(util.format_elapsed(s, f"{self._indent}FINISH read {self.uri}"))
 
         return df

--- a/apis/python/src/tiledbsc/annotation_matrix_group.py
+++ b/apis/python/src/tiledbsc/annotation_matrix_group.py
@@ -36,9 +36,9 @@ class AnnotationMatrixGroup(TileDBGroup):
     def keys(self):
         """
         For obsm and varm, `.keys()` is a keystroke-saver for the more general group-member
-        accessor `.get_member_names()`.
+        accessor `._get_member_names()`.
         """
-        return self.get_member_names()
+        return self._get_member_names()
 
     # ----------------------------------------------------------------
     def __iter__(self) -> List[AnnotationMatrix]:
@@ -46,7 +46,7 @@ class AnnotationMatrixGroup(TileDBGroup):
         Implements 'for matrix in soma.obsm: ...' and 'for matrix in soma.varm: ...'
         """
         retval = []
-        for name, uri in self.get_member_names_to_uris().items():
+        for name, uri in self._get_member_names_to_uris().items():
             matrix = AnnotationMatrix(
                 uri=uri, name=name, dim_name=self.dim_name, parent=self
             )
@@ -63,7 +63,7 @@ class AnnotationMatrixGroup(TileDBGroup):
         :param dim_values: anndata.obs_names, anndata.var_names, or anndata.raw.var_names.
         """
 
-        self.open("w")
+        self._open("w")
 
         for matrix_name in annotation_matrices.keys():
             anndata_matrix = annotation_matrices[matrix_name]
@@ -75,8 +75,8 @@ class AnnotationMatrixGroup(TileDBGroup):
                 parent=self,
             )
             annotation_matrix.from_anndata(anndata_matrix, dim_values)
-            self.add_object(annotation_matrix)
-        self.close()
+            self._add_object(annotation_matrix)
+        self._close()
 
     # ----------------------------------------------------------------
     def to_dict_of_csr(self) -> Dict[str, scipy.sparse.csr_matrix]:
@@ -91,13 +91,13 @@ class AnnotationMatrixGroup(TileDBGroup):
         except:
             pass
         if grp == None:
-            if self.verbose:
-                print(f"{self.indent}{self.uri} not found")
+            if self._verbose:
+                print(f"{self._indent}{self.uri} not found")
             return {}
 
-        if self.verbose:
+        if self._verbose:
             s = util.get_start_stamp()
-            print(f"{self.indent}START  read {self.uri}")
+            print(f"{self._indent}START  read {self.uri}")
 
         # TODO: fold this element-enumeration into the TileDB group class.  Maybe on the same PR
         # where we support somagroup['name'] with overloading of the [] operator.
@@ -105,26 +105,26 @@ class AnnotationMatrixGroup(TileDBGroup):
         for element in grp:
             with tiledb.open(element.uri) as A:
                 with tiledb.open(element.uri) as A:
-                    if self.verbose:
+                    if self._verbose:
                         s2 = util.get_start_stamp()
-                        print(f"{self.indent}START  read {element.uri}")
+                        print(f"{self._indent}START  read {element.uri}")
 
                     df = pd.DataFrame(A[:])
                     df.set_index(self.dim_name, inplace=True)
                     matrix_name = os.path.basename(element.uri)  # e.g. 'X_pca'
                     matrices_in_group[matrix_name] = df.to_numpy()
 
-                    if self.verbose:
+                    if self._verbose:
                         print(
                             util.format_elapsed(
-                                s2, f"{self.indent}FINISH read {element.uri}"
+                                s2, f"{self._indent}FINISH read {element.uri}"
                             )
                         )
 
         grp.close()
 
-        if self.verbose:
-            print(util.format_elapsed(s, f"{self.indent}FINISH read {self.uri}"))
+        if self._verbose:
+            print(util.format_elapsed(s, f"{self._indent}FINISH read {self.uri}"))
 
         return matrices_in_group
 
@@ -150,14 +150,14 @@ class AnnotationMatrixGroup(TileDBGroup):
         member exists.  Overloads the [...] operator.
         """
 
-        self.open("r")
+        self._open("r")
         obj = None
         try:
             # This returns a tiledb.object.Object.
-            obj = self.tiledb_group[name]
+            obj = self._tiledb_group[name]
         except:
             pass
-        self.close()
+        self._close()
 
         if obj is None:
             return None

--- a/apis/python/src/tiledbsc/annotation_pairwise_matrix_group.py
+++ b/apis/python/src/tiledbsc/annotation_pairwise_matrix_group.py
@@ -42,9 +42,9 @@ class AnnotationPairwiseMatrixGroup(TileDBGroup):
     def keys(self):
         """
         For obsp and varp, `.keys()` is a keystroke-saver for the more general group-member
-        accessor `.get_member_names()`.
+        accessor `._get_member_names()`.
         """
-        return self.get_member_names()
+        return self._get_member_names()
 
     # ----------------------------------------------------------------
     def __iter__(self) -> List[AnnotationPairwiseMatrix]:
@@ -52,7 +52,7 @@ class AnnotationPairwiseMatrixGroup(TileDBGroup):
         Implements 'for matrix in soma.obsp: ...' and 'for matrix in soma.varp: ...'
         """
         retval = []
-        for name, uri in self.get_member_names_to_uris().items():
+        for name, uri in self._get_member_names_to_uris().items():
             matrix = AnnotationPairwiseMatrix(
                 uri=uri,
                 name=name,
@@ -73,7 +73,7 @@ class AnnotationPairwiseMatrixGroup(TileDBGroup):
         :param dim_values: anndata.obs_names, anndata.var_names, or anndata.raw.var_names.
         """
 
-        self.open("w")
+        self._open("w")
 
         for matrix_name in annotation_pairwise_matrices.keys():
             anndata_matrix = annotation_pairwise_matrices[matrix_name]
@@ -88,8 +88,8 @@ class AnnotationPairwiseMatrixGroup(TileDBGroup):
             annotation_pairwise_matrix.from_matrix(
                 anndata_matrix, dim_values, dim_values
             )
-            self.add_object(annotation_pairwise_matrix)
-        self.close()
+            self._add_object(annotation_pairwise_matrix)
+        self._close()
 
     # ----------------------------------------------------------------
     def to_dict_of_csr(self) -> Dict[str, scipy.sparse.csr_matrix]:
@@ -104,13 +104,13 @@ class AnnotationPairwiseMatrixGroup(TileDBGroup):
         except:
             pass
         if grp == None:
-            if self.verbose:
-                print(f"{self.indent}{self.uri} not found")
+            if self._verbose:
+                print(f"{self._indent}{self.uri} not found")
             return {}
 
-        if self.verbose:
+        if self._verbose:
             s = util.get_start_stamp()
-            print(f"{self.indent}START  read {self.uri}")
+            print(f"{self._indent}START  read {self.uri}")
 
         # TODO: fold this element-enumeration into the TileDB group class.  Maybe on the same PR
         # where we support somagroup['name'] with overloading of the [] operator.
@@ -118,9 +118,9 @@ class AnnotationPairwiseMatrixGroup(TileDBGroup):
         for element in grp:
             with tiledb.open(element.uri) as A:
                 with tiledb.open(element.uri) as A:
-                    if self.verbose:
+                    if self._verbose:
                         s2 = util.get_start_stamp()
-                        print(f"{self.indent}START  read {element.uri}")
+                        print(f"{self._indent}START  read {element.uri}")
 
                     df = pd.DataFrame(A[:])
                     matrix_name = os.path.basename(
@@ -130,17 +130,17 @@ class AnnotationPairwiseMatrixGroup(TileDBGroup):
                     # TODO: not working yet:
                     # TypeError: no supported conversion for types: (dtype('O'),)
 
-                    if self.verbose:
+                    if self._verbose:
                         print(
                             util.format_elapsed(
-                                s2, f"{self.indent}FINISH read {element.uri}"
+                                s2, f"{self._indent}FINISH read {element.uri}"
                             )
                         )
 
         grp.close()
 
-        if self.verbose:
-            print(util.format_elapsed(s, f"{self.indent}FINISH read {self.uri}"))
+        if self._verbose:
+            print(util.format_elapsed(s, f"{self._indent}FINISH read {self.uri}"))
 
         return matrices_in_group
 
@@ -166,14 +166,14 @@ class AnnotationPairwiseMatrixGroup(TileDBGroup):
         member exists.  Overloads the [...] operator.
         """
 
-        self.open("r")
+        self._open("r")
         obj = None
         try:
             # This returns a tiledb.object.Object.
-            obj = self.tiledb_group[name]
+            obj = self._tiledb_group[name]
         except:
             pass
-        self.close()
+        self._close()
 
         if obj is None:
             return None

--- a/apis/python/src/tiledbsc/assay_matrix_group.py
+++ b/apis/python/src/tiledbsc/assay_matrix_group.py
@@ -45,10 +45,10 @@ class AssayMatrixGroup(TileDBGroup):
         anndata.obs_names and col_names will be anndata.var_names or anndata.raw.var_names.
         """
 
-        self.open("w")
+        self._open("w")
 
         if matrix is not None:
             self.data.from_matrix(matrix, row_names, col_names)
-            self.add_object(self.data)
+            self._add_object(self.data)
 
-        self.close()
+        self._close()

--- a/apis/python/src/tiledbsc/raw_group.py
+++ b/apis/python/src/tiledbsc/raw_group.py
@@ -57,26 +57,26 @@ class RawGroup(TileDBGroup):
         """
         Writes anndata.raw to a TileDB group structure.
         """
-        if self.verbose:
+        if self._verbose:
             s = util.get_start_stamp()
-            print(f"{self.indent}START  WRITING {self.uri}")
+            print(f"{self._indent}START  WRITING {self.uri}")
 
         # Must be done first, to create the parent directory
-        self.open("w")
+        self._open("w")
 
         self.X.from_matrix(anndata.raw.X, anndata.obs.index, anndata.raw.var.index)
-        self.add_object(self.X)
+        self._add_object(self.X)
 
         self.var.from_dataframe(dataframe=anndata.raw.var, extent=2048)
-        self.add_object(self.var)
+        self._add_object(self.var)
 
         self.varm.from_anndata(anndata.raw.varm, anndata.raw.var_names)
-        self.add_object(self.varm)
+        self._add_object(self.varm)
 
-        if self.verbose:
-            print(util.format_elapsed(s, f"{self.indent}FINISH WRITING {self.uri}"))
+        if self._verbose:
+            print(util.format_elapsed(s, f"{self._indent}FINISH WRITING {self.uri}"))
 
-        self.close()
+        self._close()
 
     # ----------------------------------------------------------------
     def to_anndata_raw(self, obs_labels):

--- a/apis/python/src/tiledbsc/tiledb_array.py
+++ b/apis/python/src/tiledbsc/tiledb_array.py
@@ -24,14 +24,14 @@ class TileDBArray(TileDBObject):
         """
         super().__init__(uri=uri, name=name, parent=parent)
 
-    def object_type(self):
+    def _object_type(self):
         """
         This should be implemented by child classes and should return what tiledb.object_type(uri)
         returns for objects of a given type -- nominally 'group' or 'array'.
         """
         return "array"
 
-    def open(self):
+    def _open(self):
         """
         Returns the TileDB array. The caller should do A.close() on the return value after finishing
         with it.

--- a/apis/python/src/tiledbsc/tiledb_group.py
+++ b/apis/python/src/tiledbsc/tiledb_group.py
@@ -11,7 +11,7 @@ class TileDBGroup(TileDBObject):
     Wraps groups from TileDB-Py by retaining a URI, verbose flag, etc.
     """
 
-    tiledb_group: Union[tiledb.Group, None]
+    _tiledb_group: Union[tiledb.Group, None]
 
     def __init__(
         self,
@@ -31,9 +31,9 @@ class TileDBGroup(TileDBObject):
         """
         super().__init__(uri=uri, name=name, parent=parent)
 
-        self.tiledb_group = None
+        self._tiledb_group = None
 
-    def object_type(self):
+    def _object_type(self):
         """
         This should be implemented by child classes and should return what tiledb.object_type(uri)
         returns for objects of a given type -- nominally 'group' or 'array'.
@@ -48,72 +48,72 @@ class TileDBGroup(TileDBObject):
         """
         return tiledb.object_type(self.uri) == "group"
 
-    def create(self):
+    def _create(self):
         """
         Creates the TileDB group data structure on disk/S3/cloud.
         """
-        if self.tiledb_group != None:
+        if self._tiledb_group != None:
             raise Exception("Attempt to create an already-open group")
-        if self.verbose:
-            print(f"{self.indent}Creating TileDB group {self.uri}")
-        tiledb.group_create(uri=self.uri, ctx=self.ctx)
+        if self._verbose:
+            print(f"{self._indent}Creating TileDB group {self.uri}")
+        tiledb.group_create(uri=self.uri, ctx=self._ctx)
 
-    def open(self, mode: str):
+    def _open(self, mode: str):
         """
         Mode must be "w" for write or "r" for read.
         """
         assert mode in ["w", "r"]
-        if self.tiledb_group != None:
+        if self._tiledb_group != None:
             raise Exception("Attempt to open an already-open group")
         if not self.exists():
-            self.create()
-        self.tiledb_group = tiledb.Group(self.uri, mode=mode, ctx=self.ctx)
+            self._create()
+        self._tiledb_group = tiledb.Group(self.uri, mode=mode, ctx=self._ctx)
 
-    def close(self):
+    def _close(self):
         """
         Should be done after open-with-write and add, or, open-with-read and read.
         """
-        if self.tiledb_group == None:
+        if self._tiledb_group == None:
             raise Exception("Attempt to close a non-open group")
-        self.tiledb_group.close()
-        self.tiledb_group = None
+        self._tiledb_group.close()
+        self._tiledb_group = None
 
-    def add_object(self, obj: TileDBObject):
-        if self.tiledb_group == None:
+    def _add_object(self, obj: TileDBObject):
+        if self._tiledb_group == None:
             raise Exception("Attempt to write to a non-open group")
-        self.tiledb_group.add(uri=obj.uri, relative=False, name=obj.name)
+        self._tiledb_group.add(uri=obj.uri, relative=False, name=obj.name)
 
-    def add_uri(self, uri: str, name: str):
-        if self.tiledb_group == None:
+    def _add_uri(self, uri: str, name: str):
+        if self._tiledb_group == None:
             raise Exception("Attempt to write to a non-open group")
-        self.tiledb_group.add(uri=uri, relative=False, name=name)
+        self._tiledb_group.add(uri=uri, relative=False, name=name)
 
-    def get_member_names(self):
+    def _get_member_names(self):
         """
         Returns the names of the group elements. For a SOMACollection, these will SOMA names;
         for a SOMA, these will be matrix/group names; etc.
         """
-        return [os.path.basename(e) for e in self.get_member_uris()]
+        return [os.path.basename(e) for e in self._get_member_uris()]
 
-    def get_member_uris(self) -> List[str]:
+    def _get_member_uris(self) -> List[str]:
         """
         Returns the URIs of the group elements. For a SOMACollection, these will SOMA URIs;
         for a SOMA, these will be matrix/group URIs; etc.
         """
-        self.open("r")
-        retval = [e.uri for e in self.tiledb_group]
-        self.close()
+        self._open("r")
+        retval = [e.uri for e in self._tiledb_group]
+        self._close()
         return retval
 
-    def get_member_names_to_uris(self) -> Dict[str, str]:
+    def _get_member_names_to_uris(self) -> Dict[str, str]:
         """
-        Like `get_member_names()` and `get_member_uris`, but returns a dict mapping from
+        Like `_get_member_names()` and `_get_member_uris`, but returns a dict mapping from
         member name to member URI.
         """
         retval = {}
-        self.open("r")
-        for e in self.tiledb_group:
+        self._open("r")
+        for e in self._tiledb_group:
             name = os.path.basename(e.uri)
             retval[name] = e.uri
-        self.close()
+        self._close()
         return retval

--- a/apis/python/src/tiledbsc/tiledb_object.py
+++ b/apis/python/src/tiledbsc/tiledb_object.py
@@ -13,11 +13,11 @@ class TileDBObject:
     uri: str
     name: str
 
-    soma_options: SOMAOptions
-    verbose: bool
-    ctx: Optional[tiledb.Ctx]
+    _soma_options: SOMAOptions
+    _verbose: bool
+    _ctx: Optional[tiledb.Ctx]
 
-    indent: str  # for display strings
+    _indent: str  # for display strings
 
     def __init__(
         self,
@@ -44,21 +44,21 @@ class TileDBObject:
         self.name = name
 
         if parent is None:
-            self.soma_options = soma_options
-            self.verbose = verbose
-            self.ctx = ctx
-            self.indent = ""
+            self._soma_options = soma_options
+            self._verbose = verbose
+            self._ctx = ctx
+            self._indent = ""
         else:
-            self.soma_options = parent.soma_options
-            self.verbose = parent.verbose
-            self.ctx = parent.ctx
-            self.indent = parent.indent + "  "
+            self._soma_options = parent._soma_options
+            self._verbose = parent._verbose
+            self._ctx = parent._ctx
+            self._indent = parent._indent + "  "
 
-        if self.soma_options is None:
-            self.soma_options = SOMAOptions()
+        if self._soma_options is None:
+            self._soma_options = SOMAOptions()
         # Null ctx is OK if that's what they wanted (e.g. not doing any TileDB-Cloud ops).
 
-    def object_type(self):
+    def _object_type(self):
         """
         This should be implemented by child classes and should return what tiledb.object_type(uri)
         returns for objects of a given type -- nominally 'group' or 'array'.
@@ -69,9 +69,9 @@ class TileDBObject:
         found = tiledb.object_type(self.uri)
         if found == None:
             return False
-        elif found == self.object_type():
+        elif found == self._object_type():
             return True
         else:
             raise Exception(
-                f"Internal error: expected object_type {self.object_type()} but found {found} at {self.uri}."
+                f"Internal error: expected _object_type {self._object_type()} but found {found} at {self.uri}."
             )

--- a/apis/python/src/tiledbsc/uns_group.py
+++ b/apis/python/src/tiledbsc/uns_group.py
@@ -40,11 +40,11 @@ class UnsGroup(TileDBGroup):
         :param uns: anndata.uns.
         """
 
-        if self.verbose:
+        if self._verbose:
             s = util.get_start_stamp()
-            print(f"{self.indent}START  WRITING {self.uri}")
+            print(f"{self._indent}START  WRITING {self.uri}")
 
-        self.open("w")
+        self._open("w")
 
         for key in uns.keys():
             component_uri = os.path.join(self.uri, key)
@@ -74,29 +74,29 @@ class UnsGroup(TileDBGroup):
                 # Nested data, e.g. a.uns['draw-graph']['params']['layout']
                 subgroup = UnsGroup(uri=component_uri, name=key, parent=self)
                 subgroup.from_anndata_uns(value)
-                self.add_object(subgroup)
+                self._add_object(subgroup)
                 continue
 
             array = UnsArray(uri=component_uri, name=key, parent=self)
 
             if isinstance(value, pd.DataFrame):
                 array.from_pandas_dataframe(value)
-                self.add_object(array)
+                self._add_object(array)
 
             elif isinstance(value, scipy.sparse.csr_matrix):
                 array.from_scipy_csr(value)
-                self.add_object(array)
+                self._add_object(array)
 
-            elif array.maybe_from_numpyable_object(value):
-                self.add_object(array)
+            elif array._maybe_from_numpyable_object(value):
+                self._add_object(array)
 
             else:
                 print("      Skipping unrecognized type:", component_uri, type(value))
 
-        self.close()
+        self._close()
 
-        if self.verbose:
-            print(util.format_elapsed(s, f"{self.indent}FINISH WRITING {self.uri}"))
+        if self._verbose:
+            print(util.format_elapsed(s, f"{self._indent}FINISH WRITING {self.uri}"))
 
     # ----------------------------------------------------------------
     def to_dict_of_matrices(self) -> Dict:
@@ -109,13 +109,13 @@ class UnsGroup(TileDBGroup):
         except:
             pass
         if grp == None:
-            if self.verbose:
-                print(f"{self.indent}{self.uri} not found")
+            if self._verbose:
+                print(f"{self._indent}{self.uri} not found")
             return {}
 
-        if self.verbose:
+        if self._verbose:
             s = util.get_start_stamp()
-            print(f"{self.indent}START  read {self.uri}")
+            print(f"{self._indent}START  read {self.uri}")
 
         # TODO: fold this element-enumeration into the TileDB group class.  Maybe on the same PR
         # where we support somagroup['name'] with overloading of the [] operator.
@@ -139,8 +139,8 @@ class UnsGroup(TileDBGroup):
 
         grp.close()
 
-        if self.verbose:
-            print(util.format_elapsed(s, f"{self.indent}FINISH read {self.uri}"))
+        if self._verbose:
+            print(util.format_elapsed(s, f"{self._indent}FINISH read {self.uri}"))
 
         return retval
 
@@ -166,14 +166,14 @@ class UnsGroup(TileDBGroup):
         no such member exists.  Overloads the [...] operator.
         """
 
-        self.open("r")
+        self._open("r")
         obj = None
         try:
             # This returns a tiledb.object.Object.
-            obj = self.tiledb_group[name]
+            obj = self._tiledb_group[name]
         except:
             pass
-        self.close()
+        self._close()
 
         if obj is None:
             return None

--- a/apis/python/src/tiledbsc/util.py
+++ b/apis/python/src/tiledbsc/util.py
@@ -28,7 +28,7 @@ def format_elapsed(start_stamp, message: str):
 
 
 # ----------------------------------------------------------------
-def find_csr_chunk_size(
+def _find_csr_chunk_size(
     mat: scipy.sparse._csr.csr_matrix,
     permutation: list,
     start_row_index: int,
@@ -56,7 +56,7 @@ def find_csr_chunk_size(
 
 
 # ----------------------------------------------------------------
-def get_sort_and_permutation(lst: list):
+def _get_sort_and_permutation(lst: list):
     """
     Sorts a list, returned the sorted list along with a permutation-index list which can be used for
     cursored access to data which was indexed by the unsorted list. Nominally for chunking of CSR
@@ -150,7 +150,7 @@ def _to_tiledb_supported_array_type(x):
 
 
 # ----------------------------------------------------------------
-def X_and_ids_to_coo(
+def _X_and_ids_to_coo(
     Xdf: pd.DataFrame,
     row_dim_name: str,
     col_dim_name: str,

--- a/apis/python/src/tiledbsc/util_ann.py
+++ b/apis/python/src/tiledbsc/util_ann.py
@@ -252,7 +252,7 @@ def _describe_ann_file_show_uns_data(uns, parent_path_components=["uns"]):
 
 
 # ----------------------------------------------------------------
-def decategoricalize(anndata: ad.AnnData):
+def _decategoricalize(anndata: ad.AnnData):
     """
     Performs an in-place typecast into types that TileDB can persist.
     """

--- a/apis/python/src/tiledbsc/util_tiledb.py
+++ b/apis/python/src/tiledbsc/util_tiledb.py
@@ -40,7 +40,7 @@ def show_single_cell_group(soma_uri: str, ctx: Optional[tiledb.Ctx] = None):
 
 
 # ----------------------------------------------------------------
-def fminus(long_path: str, short_path: str):
+def _fminus(long_path: str, short_path: str):
     return long_path.replace(short_path, "")
 
 

--- a/apis/python/tests/test_mem_fs.py
+++ b/apis/python/tests/test_mem_fs.py
@@ -27,4 +27,4 @@ def test_from_anndata_memfs():
     assert f"{path}/obs" in members
     assert f"{path}/var" in members
 
-    soma_group.close()
+    soma_group._close()

--- a/apis/python/tests/test_soma_group_indexing.py
+++ b/apis/python/tests/test_soma_group_indexing.py
@@ -47,10 +47,10 @@ def test_soma_group_indexing(h5ad_file):
     #   raw/var
     #   raw/varm/PCs
 
-    assert set(soma.get_member_names()) == set(
+    assert set(soma._get_member_names()) == set(
         ["uns", "varm", "X", "raw", "obsp", "varp", "var", "obsm", "obs"]
     )
-    assert set(soma.X.get_member_names()) == set(["data"])
+    assert set(soma.X._get_member_names()) == set(["data"])
     assert soma.X.data.dim_names() == ["obs_id", "var_id"]
 
     assert soma.obs.exists()
@@ -206,7 +206,7 @@ def test_soma_group_indexing(h5ad_file):
     ]
 
     assert soma.obsm.exists()
-    assert set(soma.obsm.get_member_names()) == set(["X_pca", "X_tsne"])
+    assert set(soma.obsm._get_member_names()) == set(["X_pca", "X_tsne"])
     assert set(soma.obsm.keys()) == set(["X_pca", "X_tsne"])
     assert soma.obsm["X_pca"].exists()
     assert isinstance(soma.obsm["X_pca"], tiledbsc.AnnotationMatrix)
@@ -236,14 +236,14 @@ def test_soma_group_indexing(h5ad_file):
         np.dtype("float64"),
     ]
 
-    assert set(soma.varm.get_member_names()) == set(["PCs"])
+    assert set(soma.varm._get_member_names()) == set(["PCs"])
     assert soma.varm["PCs"].exists()
     assert isinstance(soma.varm["PCs"], tiledbsc.AnnotationMatrix)
     assert soma.varm["nonesuch"] is None
-    assert soma.varm.get_member_names() == ["PCs"]
+    assert soma.varm._get_member_names() == ["PCs"]
     assert soma.varm["PCs"].dim_names() == ["var_id"]
 
-    assert set(soma.obsp.get_member_names()) == set(["distances"])
+    assert set(soma.obsp._get_member_names()) == set(["distances"])
     assert soma.obsp["distances"].exists()
     assert soma.obsp["distances"].dim_names() == ["obs_id_i", "obs_id_j"]
     assert isinstance(soma.obsp["distances"], tiledbsc.AnnotationPairwiseMatrix)
@@ -251,13 +251,13 @@ def test_soma_group_indexing(h5ad_file):
     assert soma.varp["nonesuch"] is None
 
     assert soma.uns.exists()
-    assert set(soma.uns.get_member_names()) == set(["neighbors"])
+    assert set(soma.uns._get_member_names()) == set(["neighbors"])
     assert soma.uns["neighbors"].exists()
     assert soma.uns.exists()
     assert isinstance(soma.uns["neighbors"], tiledbsc.UnsGroup)
-    assert set(soma.uns["neighbors"].get_member_names()) == set(["params"])
+    assert set(soma.uns["neighbors"]._get_member_names()) == set(["params"])
     assert isinstance(soma.uns["neighbors"]["params"], tiledbsc.UnsGroup)
-    assert set(soma.uns["neighbors"]["params"].get_member_names()) == set(["method"])
+    assert set(soma.uns["neighbors"]["params"]._get_member_names()) == set(["method"])
     assert isinstance(soma.uns["neighbors"]["params"]["method"], tiledbsc.UnsArray)
     assert soma.uns["nonesuch"] is None
 


### PR DESCRIPTION
While Python of course does not have method-access categories such as `public`, `protected`, or `private`, nonetheless we can more clearly mark some for-internal-use methods as being such.

Also, when a user does something like `soma.obs.` and then tries to tab-complete in the Python interpreter, the methods/attributes having leading underscores are left out by default, allowing the user to focus on methods which truly belong to the SOMA API and which aren't simply tiledb-specific implementation details toward that API. (Implementation-oriented users can tab-complete with `soma.obs._` if they like, and/or use `dir(soma.obs)`.)

This becomes ever more important as we flesh out the SOMA API last week and this week.