### PR TITLE
Use with-open-as idiom internally

### DIFF
--- a/apis/python/src/tiledbsc/annotation_dataframe.py
+++ b/apis/python/src/tiledbsc/annotation_dataframe.py
@@ -38,9 +38,7 @@ class AnnotationDataFrame(TileDBArray):
         The row-count is the number of obs_ids (for `obs`) or the number of var_ids (for `var`).
         The column-count is the number of columns/attributes in the dataframe.
         """
-        # TODO: with self._open: see
-        # https://github.com/single-cell-data/TileDB-SingleCell/pull/93
-        with tiledb.open(self.uri) as A:
+        with self._open("r") as A:
             # These TileDB arrays are string-dimensioned sparse arrays so there is no '.shape'.
             # Instead we compute it ourselves.  See also:
             # * https://github.com/single-cell-data/TileDB-SingleCell/issues/10
@@ -54,7 +52,7 @@ class AnnotationDataFrame(TileDBArray):
         """
         Returns the `obs_ids` in the matrix (for `obs`) or the `var_ids` (for `var`).
         """
-        with tiledb.open(self.uri) as A:
+        with self._open("r") as A:
             return A[:][self.dim_name].tolist()
 
     # ----------------------------------------------------------------
@@ -72,10 +70,10 @@ class AnnotationDataFrame(TileDBArray):
         If `ids` is `None`, the entire dataframe is returned.
         """
         if ids is None:
-            with tiledb.open(self.uri) as A:  # TODO: with self._open
+            with self._open("r") as A:
                 return A.df[:]
         else:
-            with tiledb.open(self.uri) as A:  # TODO: with self._open
+            with self._open("r") as A:
                 return A.df[ids]
 
     # ----------------------------------------------------------------

--- a/apis/python/src/tiledbsc/annotation_matrix.py
+++ b/apis/python/src/tiledbsc/annotation_matrix.py
@@ -37,10 +37,10 @@ class AnnotationMatrix(TileDBArray):
         `var_ids` (for `varm` elements).  If `ids` is `None`, the entire array is returned.
         """
         if ids is None:
-            with tiledb.open(self.uri) as A:  # TODO: with self._open
+            with self._open() as A:
                 return A.df[:]
         else:
-            with tiledb.open(self.uri) as A:  # TODO: with self._open
+            with self._open() as A:
                 return A.df[ids]
 
     # ----------------------------------------------------------------
@@ -58,7 +58,7 @@ class AnnotationMatrix(TileDBArray):
         The row-count is the number of obs_ids (for `obsm` elements) or the number of var_ids (for
         `varm` elements).  The column-count is the number of columns/attributes in the dataframe.
         """
-        with tiledb.open(self.uri) as A:  # TODO: with self._open
+        with self._open() as A:
             # These TileDB arrays are string-dimensioned sparse arrays so there is no '.shape'.
             # Instead we compute it ourselves.  See also:
             # * https://github.com/single-cell-data/TileDB-SingleCell/issues/10

--- a/apis/python/src/tiledbsc/annotation_matrix_group.py
+++ b/apis/python/src/tiledbsc/annotation_matrix_group.py
@@ -165,8 +165,7 @@ class AnnotationMatrixGroup(TileDBGroup):
                 )
             else:
                 raise Exception(
-                    "Internal error: found group element neither subgroup nor array: type is",
-                    str(obj.type),
+                    f"Internal error: found group element neither subgroup nor array: type is {str(obj.type)}"
                 )
 
     def __contains__(self, name):

--- a/apis/python/src/tiledbsc/annotation_matrix_group.py
+++ b/apis/python/src/tiledbsc/annotation_matrix_group.py
@@ -150,10 +150,8 @@ class AnnotationMatrixGroup(TileDBGroup):
 
         # TODO: If TileDB-Py were to support `name in G` the line-count could reduce here.
         with self._open("r") as G:
-            # This returns a tiledb.object.Object.
-            obj = None
             try:
-                obj = G[name]
+                obj = G[name]  # This returns a tiledb.object.Object.
             except:
                 return None
 
@@ -170,3 +168,18 @@ class AnnotationMatrixGroup(TileDBGroup):
                     "Internal error: found group element neither subgroup nor array: type is",
                     str(obj.type),
                 )
+
+    def __contains__(self, name):
+        """
+        Implements '"namegoeshere" in soma.obsm/soma.varm'.
+        """
+        # TODO: this will get easier once TileDB.group.Group supports `name` in `__contains__`.
+        # See SC-18057 and https://github.com/single-cell-data/TileDB-SingleCell/issues/113.
+        with self._open("r") as G:
+            answer = False
+            try:
+                # This returns a tiledb.object.Object.
+                G[name]
+                return True
+            except:
+                return False

--- a/apis/python/src/tiledbsc/annotation_pairwise_matrix.py
+++ b/apis/python/src/tiledbsc/annotation_pairwise_matrix.py
@@ -40,7 +40,7 @@ class AnnotationPairwiseMatrix(TileDBArray):
         The row-count and column-counts should be the same: dimensions are `obs_id_i,obs_id_j` for
         `obsm` elements, and `var_id_i,var_id_j` for `varm` elements.
         """
-        with tiledb.open(self.uri) as A:  # TODO: with self._open
+        with self._open() as A:
             # These TileDB arrays are string-dimensioned sparse arrays so there is no '.shape'.
             # Instead we compute it ourselves.  See also:
             # * https://github.com/single-cell-data/TileDB-SingleCell/issues/10
@@ -53,11 +53,10 @@ class AnnotationPairwiseMatrix(TileDBArray):
         Selects a slice out of the array with specified `obs_ids` (for `obsp` elements) or
         `var_ids` (for `varp` elements).  If `ids` is `None`, the entire array is returned.
         """
-        if ids is None:
-            with tiledb.open(self.uri) as A:  # TODO: with self._open
+        with self._open() as A:
+            if ids is None:
                 return A.df[:, :]
-        else:
-            with tiledb.open(self.uri) as A:  # TODO: with self._open
+            else:
                 return A.df[ids, ids]
 
     # ----------------------------------------------------------------
@@ -164,5 +163,5 @@ class AnnotationPairwiseMatrix(TileDBArray):
 
         df = pd.DataFrame(matrix, columns=col_names)
 
-        with tiledb.open(self.uri, mode="w", ctx=self._ctx) as A:
+        with self._open("w") as A:
             A[dim_values] = df.to_dict(orient="list")

--- a/apis/python/src/tiledbsc/annotation_pairwise_matrix_group.py
+++ b/apis/python/src/tiledbsc/annotation_pairwise_matrix_group.py
@@ -176,16 +176,16 @@ class AnnotationPairwiseMatrixGroup(TileDBGroup):
                 raise Exception(
                     "Internal error: found group element where array element was expected."
                 )
-            elif obj.type != tiledb.libtiledb.Array:
+            if obj.type != tiledb.libtiledb.Array:
                 raise Exception(
                     "Internal error: found group element neither subgroup nor array: type is",
                     str(obj.type),
                 )
-            else:
-                return AnnotationPairwiseMatrix(
-                    uri=obj.uri,
-                    name=name,
-                    row_dim_name=self.row_dim_name,
-                    col_dim_name=self.col_dim_name,
-                    parent=self,
-                )
+
+            return AnnotationPairwiseMatrix(
+                uri=obj.uri,
+                name=name,
+                row_dim_name=self.row_dim_name,
+                col_dim_name=self.col_dim_name,
+                parent=self,
+            )

--- a/apis/python/src/tiledbsc/annotation_pairwise_matrix_group.py
+++ b/apis/python/src/tiledbsc/annotation_pairwise_matrix_group.py
@@ -176,8 +176,7 @@ class AnnotationPairwiseMatrixGroup(TileDBGroup):
                 )
             if obj.type != tiledb.libtiledb.Array:
                 raise Exception(
-                    "Internal error: found group element neither subgroup nor array: type is",
-                    str(obj.type),
+                    f"Internal error: found group element neither subgroup nor array: type is {str(obj.type)}"
                 )
 
             return AnnotationPairwiseMatrix(

--- a/apis/python/src/tiledbsc/annotation_pairwise_matrix_group.py
+++ b/apis/python/src/tiledbsc/annotation_pairwise_matrix_group.py
@@ -165,10 +165,8 @@ class AnnotationPairwiseMatrixGroup(TileDBGroup):
         """
 
         with self._open("r") as G:
-            # This returns a tiledb.object.Object.
-            obj = None
             try:
-                obj = G[name]
+                obj = G[name]  # This returns a tiledb.object.Object.
             except:
                 return None
 
@@ -189,3 +187,18 @@ class AnnotationPairwiseMatrixGroup(TileDBGroup):
                 col_dim_name=self.col_dim_name,
                 parent=self,
             )
+
+    def __contains__(self, name):
+        """
+        Implements '"namegoeshere" in soma.obsp/soma.varp'.
+        """
+        # TODO: this will get easier once TileDB.group.Group supports `name` in `__contains__`.
+        # See SC-18057 and https://github.com/single-cell-data/TileDB-SingleCell/issues/113.
+        with self._open("r") as G:
+            answer = False
+            try:
+                # This returns a tiledb.object.Object.
+                G[name]
+                return True
+            except:
+                return False

--- a/apis/python/src/tiledbsc/assay_matrix_group.py
+++ b/apis/python/src/tiledbsc/assay_matrix_group.py
@@ -45,10 +45,7 @@ class AssayMatrixGroup(TileDBGroup):
         anndata.obs_names and col_names will be anndata.var_names or anndata.raw.var_names.
         """
 
-        self._open("w")
-
         if matrix is not None:
-            self.data.from_matrix(matrix, row_names, col_names)
-            self._add_object(self.data)
-
-        self._close()
+            with self._open("w") as G:
+                self.data.from_matrix(matrix, row_names, col_names)
+                self._add_object(G, self.data)

--- a/apis/python/src/tiledbsc/raw_group.py
+++ b/apis/python/src/tiledbsc/raw_group.py
@@ -62,21 +62,19 @@ class RawGroup(TileDBGroup):
             print(f"{self._indent}START  WRITING {self.uri}")
 
         # Must be done first, to create the parent directory
-        self._open("w")
+        with self._open("w") as G:
 
-        self.X.from_matrix(anndata.raw.X, anndata.obs.index, anndata.raw.var.index)
-        self._add_object(self.X)
+            self.X.from_matrix(anndata.raw.X, anndata.obs.index, anndata.raw.var.index)
+            self._add_object(G, self.X)
 
-        self.var.from_dataframe(dataframe=anndata.raw.var, extent=2048)
-        self._add_object(self.var)
+            self.var.from_dataframe(dataframe=anndata.raw.var, extent=2048)
+            self._add_object(G, self.var)
 
-        self.varm.from_anndata(anndata.raw.varm, anndata.raw.var_names)
-        self._add_object(self.varm)
+            self.varm.from_anndata(anndata.raw.varm, anndata.raw.var_names)
+            self._add_object(G, self.varm)
 
         if self._verbose:
             print(util.format_elapsed(s, f"{self._indent}FINISH WRITING {self.uri}"))
-
-        self._close()
 
     # ----------------------------------------------------------------
     def to_anndata_raw(self, obs_labels):

--- a/apis/python/src/tiledbsc/soma.py
+++ b/apis/python/src/tiledbsc/soma.py
@@ -219,49 +219,45 @@ class SOMA(TileDBGroup):
             s = util.get_start_stamp()
             print(f"{self._indent}START  WRITING {self.uri}")
 
-        # ----------------------------------------------------------------
         # Must be done first, to create the parent directory
-        self._open("w")
+        with self._open("w") as G:
 
-        # ----------------------------------------------------------------
-        self.X.from_matrix(anndata.X, anndata.obs.index, anndata.var.index)
-        self._add_object(self.X)
+            # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+            self.X.from_matrix(anndata.X, anndata.obs.index, anndata.var.index)
+            self._add_object(G, self.X)
 
-        # ----------------------------------------------------------------
-        self.obs.from_dataframe(dataframe=anndata.obs, extent=256)
-        self._add_object(self.obs)
+            # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+            self.obs.from_dataframe(dataframe=anndata.obs, extent=256)
+            self._add_object(G, self.obs)
 
-        self.var.from_dataframe(dataframe=anndata.var, extent=2048)
-        self._add_object(self.var)
+            self.var.from_dataframe(dataframe=anndata.var, extent=2048)
+            self._add_object(G, self.var)
 
-        # ----------------------------------------------------------------
-        self.obsm.from_anndata(anndata.obsm, anndata.obs_names)
-        self._add_object(self.obsm)
+            # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+            self.obsm.from_anndata(anndata.obsm, anndata.obs_names)
+            self._add_object(G, self.obsm)
 
-        self.varm.from_anndata(anndata.varm, anndata.var_names)
-        self._add_object(self.varm)
+            self.varm.from_anndata(anndata.varm, anndata.var_names)
+            self._add_object(G, self.varm)
 
-        self.obsp.from_anndata(anndata.obsp, anndata.obs_names)
-        self._add_object(self.obsp)
+            self.obsp.from_anndata(anndata.obsp, anndata.obs_names)
+            self._add_object(G, self.obsp)
 
-        self.varp.from_anndata(anndata.varp, anndata.var_names)
-        self._add_object(self.varp)
+            self.varp.from_anndata(anndata.varp, anndata.var_names)
+            self._add_object(G, self.varp)
 
-        # ----------------------------------------------------------------
-        if anndata.raw != None:
-            self.raw.from_anndata(anndata)
-            self._add_object(self.raw)
+            # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+            if anndata.raw != None:
+                self.raw.from_anndata(anndata)
+                self._add_object(G, self.raw)
 
-        # ----------------------------------------------------------------
-        if anndata.uns != None:
-            self.uns.from_anndata_uns(anndata.uns)
-            self._add_object(self.uns)
+            # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+            if anndata.uns != None:
+                self.uns.from_anndata_uns(anndata.uns)
+                self._add_object(G, self.uns)
 
-        # ----------------------------------------------------------------
         if self._verbose:
             print(util.format_elapsed(s, f"{self._indent}FINISH WRITING {self.uri}"))
-
-        self._close()
 
     # ================================================================
     # READ PATH OUT OF TILEDB

--- a/apis/python/src/tiledbsc/uns_array.py
+++ b/apis/python/src/tiledbsc/uns_array.py
@@ -77,7 +77,7 @@ class UnsArray(TileDBArray):
             self.from_numpy_ndarray(arr)
             return True
 
-        elif isinstance(obj, int) or isinstance(obj, float) or isinstance(obj, str):
+        elif isinstance(obj, (int, float, str)):
             # Nominally this is unit-test data
             arr = np.asarray([obj])
             self.from_numpy_ndarray(arr)

--- a/apis/python/src/tiledbsc/uns_group.py
+++ b/apis/python/src/tiledbsc/uns_group.py
@@ -197,6 +197,8 @@ class UnsGroup(TileDBGroup):
         Implements '"namegoeshere" in soma.uns'.
         """
 
+        # TODO: this will get easier once TileDB.group.Group supports `name` in `__contains__`.
+        # See SC-18057 and https://github.com/single-cell-data/TileDB-SingleCell/issues/113.
         with self._open("r") as G:
             answer = False
             try:

--- a/apis/python/src/tiledbsc/uns_group.py
+++ b/apis/python/src/tiledbsc/uns_group.py
@@ -78,9 +78,7 @@ class UnsGroup(TileDBGroup):
                     print("      Skipping structured array:", component_uri)
                     continue
 
-                if isinstance(value, dict) or isinstance(
-                    value, ad.compat.OverloadedDict
-                ):
+                if isinstance(value, (dict, ad.compat.OverloadedDict)):
                     # Nested data, e.g. a.uns['draw-graph']['params']['layout']
                     subgroup = UnsGroup(uri=component_uri, name=key, parent=self)
                     subgroup.from_anndata_uns(value)

--- a/apis/python/src/tiledbsc/uns_group.py
+++ b/apis/python/src/tiledbsc/uns_group.py
@@ -175,10 +175,8 @@ class UnsGroup(TileDBGroup):
         """
 
         with self._open("r") as G:
-            obj = None
             try:
-                # This returns a tiledb.object.Object.
-                obj = G[name]
+                obj = G[name]  # This returns a tiledb.object.Object.
             except:
                 return None
 

--- a/apis/python/src/tiledbsc/uns_group.py
+++ b/apis/python/src/tiledbsc/uns_group.py
@@ -141,8 +141,7 @@ class UnsGroup(TileDBGroup):
 
             else:
                 raise Exception(
-                    "Internal error: found uns group element neither group nor array: type is",
-                    str(element.type),
+                    f"Internal error: found uns group element neither group nor array: type is {str(element.type)}"
                 )
 
         grp.close()
@@ -186,8 +185,7 @@ class UnsGroup(TileDBGroup):
                 return UnsArray(uri=obj.uri, name=name, parent=self)
             else:
                 raise Exception(
-                    "Internal error: found group element neither subgroup nor array: type is",
-                    str(obj.type),
+                    f"Internal error: found uns group element neither subgroup nor array: type is {str(obj.type)}"
                 )
 
     def __contains__(self, name):

--- a/apis/python/src/tiledbsc/uns_group.py
+++ b/apis/python/src/tiledbsc/uns_group.py
@@ -52,56 +52,58 @@ class UnsGroup(TileDBGroup):
             s = util.get_start_stamp()
             print(f"{self._indent}START  WRITING {self.uri}")
 
-        self._open("w")
+        with self._open("w") as G:
 
-        for key in uns.keys():
-            component_uri = os.path.join(self.uri, key)
-            value = uns[key]
+            for key in uns.keys():
+                component_uri = os.path.join(self.uri, key)
+                value = uns[key]
 
-            if key == "rank_genes_groups":
-                # TODO:
-                # This is of type 'structured array':
-                # https://numpy.org/doc/stable/user/basics.rec.html
-                #
-                # >>> a.uns['rank_genes_groups']['names'].dtype
-                # dtype([('0', 'O'), ('1', 'O'), ('2', 'O'), ('3', 'O'), ('4', 'O'), ('5', 'O'), ('6', 'O'), ('7', 'O')])
-                # >>> type(a.uns['rank_genes_groups']['names'])
-                # <class 'numpy.ndarray'>
-                #
-                # We don’t have a way to model this directly in TileDB schema right now. We support
-                # multiplicities of a single scalar type, e.g. a record array with cell_val_num==3
-                # and float32 slots (which would correspond to numpy record array
-                # np.dtype([("field1", "f4"), ("field2", "f4"), ("field3", "f4",)])). We don’t
-                # support nested cells, AKA "list" type.
-                #
-                # This could, however, be converted to a dataframe and ingested that way.
-                print("      Skipping structured array:", component_uri)
-                continue
+                if key == "rank_genes_groups":
+                    # TODO:
+                    # This is of type 'structured array':
+                    # https://numpy.org/doc/stable/user/basics.rec.html
+                    #
+                    # >>> a.uns['rank_genes_groups']['names'].dtype
+                    # dtype([('0', 'O'), ('1', 'O'), ('2', 'O'), ('3', 'O'), ('4', 'O'), ('5', 'O'), ('6', 'O'), ('7', 'O')])
+                    # >>> type(a.uns['rank_genes_groups']['names'])
+                    # <class 'numpy.ndarray'>
+                    #
+                    # We don’t have a way to model this directly in TileDB schema right now. We support
+                    # multiplicities of a single scalar type, e.g. a record array with cell_val_num==3
+                    # and float32 slots (which would correspond to numpy record array
+                    # np.dtype([("field1", "f4"), ("field2", "f4"), ("field3", "f4",)])). We don’t
+                    # support nested cells, AKA "list" type.
+                    #
+                    # This could, however, be converted to a dataframe and ingested that way.
+                    print("      Skipping structured array:", component_uri)
+                    continue
 
-            if isinstance(value, dict) or isinstance(value, ad.compat.OverloadedDict):
-                # Nested data, e.g. a.uns['draw-graph']['params']['layout']
-                subgroup = UnsGroup(uri=component_uri, name=key, parent=self)
-                subgroup.from_anndata_uns(value)
-                self._add_object(subgroup)
-                continue
+                if isinstance(value, dict) or isinstance(
+                    value, ad.compat.OverloadedDict
+                ):
+                    # Nested data, e.g. a.uns['draw-graph']['params']['layout']
+                    subgroup = UnsGroup(uri=component_uri, name=key, parent=self)
+                    subgroup.from_anndata_uns(value)
+                    self._add_object(G, subgroup)
+                    continue
 
-            array = UnsArray(uri=component_uri, name=key, parent=self)
+                array = UnsArray(uri=component_uri, name=key, parent=self)
 
-            if isinstance(value, pd.DataFrame):
-                array.from_pandas_dataframe(value)
-                self._add_object(array)
+                if isinstance(value, pd.DataFrame):
+                    array.from_pandas_dataframe(value)
+                    self._add_object(G, array)
 
-            elif isinstance(value, scipy.sparse.csr_matrix):
-                array.from_scipy_csr(value)
-                self._add_object(array)
+                elif isinstance(value, scipy.sparse.csr_matrix):
+                    array.from_scipy_csr(value)
+                    self._add_object(G, array)
 
-            elif array._maybe_from_numpyable_object(value):
-                self._add_object(array)
+                elif array._maybe_from_numpyable_object(value):
+                    self._add_object(G, array)
 
-            else:
-                print("      Skipping unrecognized type:", component_uri, type(value))
-
-        self._close()
+                else:
+                    print(
+                        "      Skipping unrecognized type:", component_uri, type(value)
+                    )
 
         if self._verbose:
             print(util.format_elapsed(s, f"{self._indent}FINISH WRITING {self.uri}"))
@@ -174,40 +176,34 @@ class UnsGroup(TileDBGroup):
         no such member exists.  Overloads the [...] operator.
         """
 
-        self._open("r")
-        obj = None
-        try:
-            # This returns a tiledb.object.Object.
-            obj = self._tiledb_group[name]
-        except:
-            pass
-        self._close()
+        with self._open("r") as G:
+            obj = None
+            try:
+                # This returns a tiledb.object.Object.
+                obj = G[name]
+            except:
+                return None
 
-        if obj is None:
-            return None
-        elif obj.type == tiledb.tiledb.Group:
-            return UnsGroup(uri=obj.uri, name=name, parent=self)
-        elif obj.type == tiledb.libtiledb.Array:
-            return UnsArray(uri=obj.uri, name=name, parent=self)
-        else:
-            raise Exception(
-                "Internal error: found group element neither subgroup nor array: type is",
-                str(obj.type),
-            )
+            if obj.type == tiledb.tiledb.Group:
+                return UnsGroup(uri=obj.uri, name=name, parent=self)
+            elif obj.type == tiledb.libtiledb.Array:
+                return UnsArray(uri=obj.uri, name=name, parent=self)
+            else:
+                raise Exception(
+                    "Internal error: found group element neither subgroup nor array: type is",
+                    str(obj.type),
+                )
 
     def __contains__(self, name):
         """
         Implements '"namegoeshere" in soma.uns'.
         """
 
-        self._open("r")
-        answer = False
-        try:
-            # This returns a tiledb.object.Object.
-            self._tiledb_group[name]
-            answer = True
-        except:
-            pass
-        self._close()
-
-        return answer
+        with self._open("r") as G:
+            answer = False
+            try:
+                # This returns a tiledb.object.Object.
+                G[name]
+                return True
+            except:
+                return False

--- a/apis/python/src/tiledbsc/util_ann.py
+++ b/apis/python/src/tiledbsc/util_ann.py
@@ -83,9 +83,7 @@ def _describe_ann_file_show_types(anndata: ad.AnnData, input_path: str):
     m, n = X.shape
     print("%-*s (%d, %d)" % (namewidth, "X/data shape", m, n))
     print("%-*s %s" % (namewidth, "X/data dtype", X.dtype))
-    if isinstance(X, scipy.sparse._csr.csr_matrix) or isinstance(
-        X, scipy.sparse._csc.csc_matrix
-    ):
+    if isinstance(X, (scipy.sparse._csr.csr_matrix, X, scipy.sparse._csc.csc_matrix)):
         density = X.nnz / (m * n)
         print("%-*s %.4f" % (namewidth, "X/data density", density))
 
@@ -102,8 +100,8 @@ def _describe_ann_file_show_types(anndata: ad.AnnData, input_path: str):
         m, n = X.shape
         print("%-*s (%d, %d)" % (namewidth, "X/raw shape", m, n))
         print("%-*s %s" % (namewidth, "X/data dtype", X.dtype))
-        if isinstance(X, scipy.sparse._csr.csr_matrix) or isinstance(
-            X, scipy.sparse._csc.csc_matrix
+        if isinstance(
+            X, (scipy.sparse._csr.csr_matrix, X, scipy.sparse._csc.csc_matrix)
         ):
             density = X.nnz / (m * n)
             print("%-*s %.4f" % (namewidth, "X/raw density", density))
@@ -192,7 +190,7 @@ def _describe_ann_file_show_uns_summary(
         current_path_components = parent_path_components + [key]
         value = uns[key]
         display_name = os.path.sep.join(current_path_components)
-        if isinstance(value, dict) or isinstance(value, ad.compat.OverloadedDict):
+        if isinstance(value, (dict, ad.compat.OverloadedDict)):
             _describe_ann_file_show_uns_summary(value, current_path_components)
         else:
             print(display_name)
@@ -208,7 +206,7 @@ def _describe_ann_file_show_uns_types(uns, parent_path_components=["uns"]):
         current_path_components = parent_path_components + [key]
         value = uns[key]
         display_name = os.path.sep.join(current_path_components)
-        if isinstance(value, dict) or isinstance(value, ad.compat.OverloadedDict):
+        if isinstance(value, (dict, ad.compat.OverloadedDict)):
             _describe_ann_file_show_uns_types(value, current_path_components)
         elif isinstance(value, np.ndarray):
             print(
@@ -217,9 +215,7 @@ def _describe_ann_file_show_uns_types(uns, parent_path_components=["uns"]):
                 type(value),
                 value.dtype,
             )
-        elif isinstance(value, scipy.sparse.csr_matrix) or isinstance(
-            value, pd.DataFrame
-        ):
+        elif isinstance(value, (scipy.sparse.csr_matrix, pd.DataFrame)):
             print("%-*s" % (namewidth, display_name), value.shape, type(value))
         else:
             print("%-*s" % (namewidth, display_name), type(value))
@@ -235,7 +231,7 @@ def _describe_ann_file_show_uns_data(uns, parent_path_components=["uns"]):
         current_path_components = parent_path_components + [key]
         value = uns[key]
         display_name = os.path.sep.join(current_path_components)
-        if isinstance(value, dict) or isinstance(value, ad.compat.OverloadedDict):
+        if isinstance(value, (dict, ad.compat.OverloadedDict)):
             _describe_ann_file_show_uns_data(value, current_path_components)
         elif (
             isinstance(value, np.ndarray)

--- a/apis/python/tests/test_mem_fs.py
+++ b/apis/python/tests/test_mem_fs.py
@@ -20,11 +20,9 @@ def test_from_anndata_memfs():
     sg = SOMA(path)
     sg.from_anndata(adata)
 
-    soma_group = tiledb.Group(sg.uri)
-    assert soma_group is not None
-    members = [mbr.uri for mbr in soma_group]
-    assert f"{path}/X" in members
-    assert f"{path}/obs" in members
-    assert f"{path}/var" in members
-
-    soma_group._close()
+    with tiledb.Group(sg.uri) as G:
+        assert G is not None
+        members = [mbr.uri for mbr in G]
+        assert f"{path}/X" in members
+        assert f"{path}/obs" in members
+        assert f"{path}/var" in members


### PR DESCRIPTION
Previously I was spelling out calls to `self._open()` and `self._close()`. Issues:

* The`with-as` syntax is more compact and more pythonic
* Having `self._open()` set `self._tiledb_group` for other methods to use until `self._close()` introduced a mysterious-looking quasi-global
* Abnormal exits were causing a "group is already open" on subsequent accesses

To do:

* As commented clearly in `tiledb_array.py`, with-open-as and open/close pairs both work correclty for arrays, using a single `_open` method.
* As also commented in `tiledb_group.py`, with-open-as and open/close pairs require two separate methods for groups, until the `TileDB-Py` `Group` object has an `__enter__`/`__exit__` pair defined on it.

CC (and a big thank-you) to @thetorpedodog for a fantastic conversation about with-as and contextmanager syntax and semantics. :)