### PR TITLE
Store uns scalars as group metadata, not 1D arrays

### DIFF
--- a/apis/python/src/tiledbsc/uns_array.py
+++ b/apis/python/src/tiledbsc/uns_array.py
@@ -71,18 +71,6 @@ class UnsArray(TileDBArray):
             self.from_numpy_ndarray(arr)
             return True
 
-        elif isinstance(obj, np.str_):
-            # Needs explicit cast from numpy.str_ to str for tiledb.from_numpy
-            arr = np.asarray([obj]).astype(str)
-            self.from_numpy_ndarray(arr)
-            return True
-
-        elif isinstance(obj, (int, float, str)):
-            # Nominally this is unit-test data
-            arr = np.asarray([obj])
-            self.from_numpy_ndarray(arr)
-            return True
-
         elif "numpy" in str(type(obj)):
             arr = np.asarray([obj])
             arr = util._to_tiledb_supported_array_type(arr)

--- a/apis/python/src/tiledbsc/uns_group.py
+++ b/apis/python/src/tiledbsc/uns_group.py
@@ -10,7 +10,7 @@ import pandas as pd
 import numpy as np
 import scipy
 
-from typing import Optional, Dict
+from typing import Optional, List, Dict, Union
 
 import os
 
@@ -39,6 +39,107 @@ class UnsGroup(TileDBGroup):
         accessor `._get_member_names()`.
         """
         return self._get_member_names()
+
+    # At the tiledb-py API level, *all* groups are name-indexable.  But here at the tiledbsc-py
+    # level, we implement name-indexing only for some groups:
+    #
+    # * Most soma member references are done using Python's dot syntax. For example, rather than
+    #   soma['X'], we have simply soma.X, and likewise, soma.raw.X.  Likewise soma.obs and soma.var.
+    #
+    # * Index references are supported for obsm, varm, obsp, varp, and uns. E.g.
+    #   soma.obsm['X_pca'] or soma.uns['neighbors']['params']['method']
+    #
+    # * Overloading the `[]` operator at the TileDBGroup level isn't necessary -- e.g. we don't need
+    #   soma['X'] when we have soma.X -- but also it causes circular-import issues in Python.
+    #
+    # * Rather than doing a TileDBIndexableGroup which overloads the `[]` operator, we overload
+    #   the `[]` operator separately in the various classes which need indexing. This is again to
+    #   avoid circular-import issues, and means that [] on `AnnotationMatrixGroup` will return an
+    #   `AnnotationMatrix, [] on `UnsGroup` will return `UnsArray` or `UnsGroup`, etc.
+    def __getitem__(self, name):
+        """
+        Returns an `UnsArray` or `UnsGroup` element at the given name within the group, or None if
+        no such member exists.  Overloads the [...] operator.
+        """
+
+        with self._open("r") as G:
+            if not name in G:
+                return None
+
+            print("<<", self.uri, ">>", "NAME", name, "TYPE", type(name))
+
+            obj = G[name]  # This returns a tiledb.object.Object.
+            if obj.type == tiledb.tiledb.Group:
+                return UnsGroup(uri=obj.uri, name=name, parent=self)
+            elif obj.type == tiledb.libtiledb.Array:
+                return UnsArray(uri=obj.uri, name=name, parent=self)
+            else:
+                raise Exception(
+                    f"Internal error: found uns group element neither subgroup nor array: type is {str(obj.type)}"
+                )
+
+    # ----------------------------------------------------------------
+    def __contains__(self, name):
+        """
+        Implements '"namegoeshere" in soma.uns'.
+        """
+        with self._open("r") as G:
+            return name in G
+
+    # ----------------------------------------------------------------
+    def __iter__(self) -> List:  # List[Union[UnsGroup, UnsArray]]
+        """
+        Implements `for element in soma.uns: ...`
+        """
+        retval = []
+        with self._open("r") as G:
+            for O in G:  # tiledb.object.Object
+                if O.type == tiledb.tiledb.Group:
+                    retval.append(UnsGroup(uri=O.uri, name=O.name, parent=self))
+                elif O.type == tiledb.libtiledb.Array:
+                    retval.append(UnsArray(uri=O.uri, name=O.name, parent=self))
+                else:
+                    raise Exception(
+                        f"Internal error: found uns group element neither subgroup nor array: type is {str(O.type)}"
+                    )
+        return iter(retval)
+
+    # ----------------------------------------------------------------
+    def show(self, display_name="uns"):
+        """
+        Recursively displays the uns data.
+        """
+        print()
+        print(display_name + ":")
+        for k, v in self.metadata().items():
+            if not k.startswith("__"):
+                print(k + ":", v)
+        for e in self:
+            element_display_name = display_name + "/" + e.name
+            if isinstance(e, UnsGroup):
+                e.show(display_name=element_display_name)
+            else:
+                print(element_display_name + "/")
+                with e._open() as A:
+                    print(A[:])
+
+        # uns:
+        # scalar_float: 3.25
+        # scalar_string: a string
+        # [1]
+        # [ 0.    1.25  2.5   3.75  5.    6.25  7.5   8.75 10.   11.25]
+        # [ 0 10 20 30 40 50 60 70 80 90]
+        # [1 2 3]
+        # [[1. 2. 3.]
+        #  [4. 5. 6.]]
+        #
+        # uns/simple_dict:
+        # B: one
+        # [0]
+        # ['a' 'b' 'c']
+        # OrderedDict([('A', array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9], dtype=int32)), ('__tiledb_rows', array([b'0', b'1', b'2', b'3', b'4', b'5', b'6', b'7', b'8', b'9'],
+        #       dtype=object))])
+        # ['0' '100' '200' '300' '400' '500' '600' '700' '800' '900']
 
     # ----------------------------------------------------------------
     def from_anndata_uns(self, uns: ad.compat.OverloadedDict):
@@ -86,6 +187,21 @@ class UnsGroup(TileDBGroup):
                 self._add_object(subgroup)
                 continue
 
+            # Write scalars as metadata, not length-1 component arrays
+            if isinstance(value, np.str_):
+                with self._open("w") as G:
+                    G.meta[key] = value
+                # TODO: WUT
+                # Needs explicit cast from numpy.str_ to str for tiledb.from_numpy
+                continue
+
+            if isinstance(value, (int, float, str)):
+                # Nominally this is unit-test data
+                with self._open("w") as G:
+                    G.meta[key] = value
+                continue
+
+            # Everything else is a component array, or unhandleable
             array = UnsArray(uri=component_uri, name=key, parent=self)
 
             if isinstance(value, pd.DataFrame):
@@ -145,47 +261,3 @@ class UnsGroup(TileDBGroup):
             print(util.format_elapsed(s, f"{self._indent}FINISH read {self.uri}"))
 
         return retval
-
-    # At the tiledb-py API level, *all* groups are name-indexable.  But here at the tiledbsc-py
-    # level, we implement name-indexing only for some groups:
-    #
-    # * Most soma member references are done using Python's dot syntax. For example, rather than
-    #   soma['X'], we have simply soma.X, and likewise, soma.raw.X.  Likewise soma.obs and soma.var.
-    #
-    # * Index references are supported for obsm, varm, obsp, varp, and uns. E.g.
-    #   soma.obsm['X_pca'] or soma.uns['neighbors']['params']['method']
-    #
-    # * Overloading the `[]` operator at the TileDBGroup level isn't necessary -- e.g. we don't need
-    #   soma['X'] when we have soma.X -- but also it causes circular-import issues in Python.
-    #
-    # * Rather than doing a TileDBIndexableGroup which overloads the `[]` operator, we overload
-    #   the `[]` operator separately in the various classes which need indexing. This is again to
-    #   avoid circular-import issues, and means that [] on `AnnotationMatrixGroup` will return an
-    #   `AnnotationMatrix, [] on `UnsGroup` will return `UnsArray` or `UnsGroup`, etc.
-    def __getitem__(self, name):
-        """
-        Returns an `UnsArray` or `UnsGroup` element at the given name within the group, or None if
-        no such member exists.  Overloads the [...] operator.
-        """
-
-        with self._open("r") as G:
-            try:
-                obj = G[name]  # This returns a tiledb.object.Object.
-            except:
-                return None
-
-            if obj.type == tiledb.tiledb.Group:
-                return UnsGroup(uri=obj.uri, name=name, parent=self)
-            elif obj.type == tiledb.libtiledb.Array:
-                return UnsArray(uri=obj.uri, name=name, parent=self)
-            else:
-                raise Exception(
-                    f"Internal error: found uns group element neither subgroup nor array: type is {str(obj.type)}"
-                )
-
-    def __contains__(self, name):
-        """
-        Implements '"namegoeshere" in soma.uns'.
-        """
-        with self._open("r") as G:
-            return name in G


### PR DESCRIPTION
Context: #88 

Example data:

```
>>> soma = tiledbsc.SOMA('tiledb-data/brown-adipose-tissue-mouse')

>>> soma.uns.show()

uns:
X_normalization: log1p, base e, scaled
publication_doi: https://doi.org/10.1038/s41586-020-2496-1
schema_version: 2.0.0
title: Brown adipose tissue — A single-cell transcriptomic atlas characterizes ageing tissues in the mouse

uns/layer_descriptions:
X: log(counts_per_thousand+1)
raw.X: raw

uns/neighbors:

uns/neighbors/params:
uns/neighbors/params/n_pcs/
[5]
uns/neighbors/params/metric/
['euclidean']
uns/neighbors/params/method/
['umap']
uns/neighbors/params/n_neighbors/
[15]

uns/louvain:

uns/louvain/params:
uns/louvain/params/random_state/
[0]

uns/leiden:

uns/leiden/params:
uns/leiden/params/random_state/
[0]
uns/leiden/params/n_iterations/
[-1]
uns/leiden/params/resolution/
[1]
uns/age_colors/
['#e1f3b2' '#97d6b9' '#1f80b8']

uns/pca:
uns/pca/variance/
[113.979164   97.67646    67.93497    56.686123   43.88914    23.913618
  23.484827   22.598204   20.3256     16.948996   14.354713   13.151188
  11.807495   10.862301   10.696552   10.350647   10.0984745   9.615314
   9.299154    8.849509    8.519048    8.121199    7.8701077   7.6040773
   7.582742    7.469643    7.2797194   7.218048    7.066573    6.9701815
   6.914394    6.772224    6.7097783   6.620041    6.520022    6.416898
   6.396799    6.333943    6.2921176   6.22901     6.15171     6.124492
   6.089446    6.0435967   6.022932    5.935481    5.910855    5.874158
   5.8458056   5.801149 ]
uns/pca/variance_ratio/
[0.03001015 0.02571773 0.01788694 0.01492518 0.01155579 0.00629634
 0.00618344 0.00595    0.00535163 0.00446259 0.00377953 0.00346264
 0.00310886 0.00285999 0.00281635 0.00272527 0.00265888 0.00253166
 0.00244842 0.00233003 0.00224302 0.00213827 0.00207216 0.00200212
 0.0019965  0.00196672 0.00191671 0.00190048 0.00186059 0.00183521
 0.00182053 0.00178309 0.00176665 0.00174302 0.00171669 0.00168954
 0.00168425 0.0016677  0.00165668 0.00164007 0.00161972 0.00161255
 0.00160332 0.00159125 0.00158581 0.00156278 0.0015563  0.00154664
 0.00153917 0.00152741]
```