### PR TITLE
Initial group/array metadata access methods

### DIFF
--- a/apis/python/src/tiledbsc/tiledb_group.py
+++ b/apis/python/src/tiledbsc/tiledb_group.py
@@ -131,4 +131,4 @@ class TileDBGroup(TileDBObject):
         member name to member URI.
         """
         with self._open("r") as G:
-            return {E.name: E.uri for E in G}
+            return {O.name: O.uri for O in G}

--- a/apis/python/src/tiledbsc/tiledb_object.py
+++ b/apis/python/src/tiledbsc/tiledb_object.py
@@ -1,7 +1,7 @@
 import tiledb
 from .soma_options import SOMAOptions
 
-from typing import Optional
+from typing import Optional, List, Dict
 
 import os
 
@@ -80,3 +80,44 @@ class TileDBObject:
             raise Exception(
                 f"Internal error: expected _object_type {self._object_type()} but found {found} at {self.uri}."
             )
+
+    def metadata(self) -> Dict:
+        """
+        Returns metadata from the group/array as a dict.
+        """
+        with self._open("r") as O:
+            # The _open method is implemented by TileDBArray and TileDBGroup
+            return dict(O.meta)
+
+    def has_metadata(self, key):
+        """
+        Returns whether metadata is associated with the group/array.
+        """
+        with self._open("r") as O:
+            # The _open method is implemented by TileDBArray and TileDBGroup
+            return key in O.meta
+
+    def metadata_keys(self) -> List[str]:
+        """
+        Returns metadata keys associated with the group/array.
+        """
+        with self._open("r") as O:
+            # The _open method is implemented by TileDBArray and TileDBGroup
+            return list(O.meta.keys())
+
+    def get_metadata(self, key):
+        """
+        Returns metadata associated with the group/array.
+        Raises `KeyError` if there is no such key in the metadata.
+        """
+        with self._open("r") as O:
+            # The _open method is implemented by TileDBArray and TileDBGroup
+            return O.meta[key]
+
+    def set_metadata(self, key: str, value) -> None:
+        """
+        Returns metadata associated with the group/array.
+        """
+        with self._open("w") as O:
+            # The _open method is implemented by TileDBArray and TileDBGroup
+            O.meta[key] = value

--- a/apis/python/src/tiledbsc/uns_group.py
+++ b/apis/python/src/tiledbsc/uns_group.py
@@ -7,8 +7,8 @@ import tiledbsc.util as util
 
 import anndata as ad
 import pandas as pd
+import numpy as np
 import scipy
-import numpy
 
 from typing import Optional, Dict
 

--- a/apis/python/src/tiledbsc/util_tiledb.py
+++ b/apis/python/src/tiledbsc/util_tiledb.py
@@ -40,11 +40,6 @@ def show_single_cell_group(soma_uri: str, ctx: Optional[tiledb.Ctx] = None):
 
 
 # ----------------------------------------------------------------
-def _fminus(long_path: str, short_path: str):
-    return long_path.replace(short_path, "")
-
-
-# ----------------------------------------------------------------
 def __show_array_schema(uri: str, ctx: Optional[tiledb.Ctx] = None):
     print("----------------------------------------------------------------")
     print("Array:", uri)

--- a/apis/python/tests/test_soma_metadata.py
+++ b/apis/python/tests/test_soma_metadata.py
@@ -1,0 +1,53 @@
+import anndata
+import tiledb
+import tiledbsc
+import tiledbsc.io
+
+import numpy as np
+
+import pytest
+import tempfile
+import os
+from pathlib import Path
+
+HERE = Path(__file__).parent
+
+
+@pytest.fixture
+def h5ad_file(request):
+    input_path = HERE.parent / "anndata/pbmc-small.h5ad"
+    return input_path
+
+
+def test_soma_metadata(h5ad_file):
+    """
+    Verify basic metadata access at the tiledbsc-py level.
+    """
+
+    # Set up anndata input path and tiledb-group output path
+    tempdir = tempfile.TemporaryDirectory()
+    output_path = tempdir.name
+
+    # Ingest
+    soma = tiledbsc.SOMA(output_path, verbose=False)
+    tiledbsc.io.from_h5ad(soma, h5ad_file)
+    assert soma.exists()
+
+    # Group-level metadata
+    assert soma.has_metadata("nonesuch") == False
+
+    soma.set_metadata("foo", "bar")
+    assert soma.has_metadata("nonesuch") == False
+    assert soma.has_metadata("foo") == True
+    assert soma.get_metadata("foo") == "bar"
+
+    # Array-level metadata
+    assert soma.obs.has_metadata("nonesuch") == False
+
+    soma.obs.set_metadata("foo", "bar")
+    assert soma.obs.has_metadata("nonesuch") == False
+    assert soma.obs.has_metadata("foo") == True
+    assert "foo" in soma.obs.metadata_keys()
+    assert soma.obs.get_metadata("foo") == "bar"
+
+    tempdir.cleanup()


### PR DESCRIPTION
This introduces some metadata accessors but doesn't yet put them to use.

Places to use them include #106, where:

* For columns, we'll store original category-type names (for anndata categoricals which were downcast to TileDB strings)
* For arrays, we'll store information like "this was originally CSR" or "this was originally CSC"
* For `uns`, we'll store scalars no longer as length-1 arrays but rather as group metadata
* For SOMA objects, we'll store information like "this was written by `tiledbsc-r v0.1.2`

See also #115 which is stacked atop this.

Note: this is stacked atop #144, hence the higher line-count -- see https://github.com/single-cell-data/TileDB-SingleCell/pull/116/commits