### PR TITLE
Support soma.X.shape(), initial implementation

### DIFF
--- a/apis/python/src/tiledbsc/annotation_matrix.py
+++ b/apis/python/src/tiledbsc/annotation_matrix.py
@@ -31,6 +31,22 @@ class AnnotationMatrix(TileDBArray):
         self.dim_name = dim_name
 
     # ----------------------------------------------------------------
+    def shape(self):
+        """
+        Returns a tuple with the number of rows and number of columns of the `AnnotationMatrix`.
+        The row-count is the number of obs_ids (for `obsm` elements) or the number of var_ids (for
+        `varm` elements).  The column-count is the number of columns/attributes in the dataframe.
+        """
+        with self._open() as A:
+            # These TileDB arrays are string-dimensioned sparse arrays so there is no '.shape'.
+            # Instead we compute it ourselves.  See also:
+            # * https://github.com/single-cell-data/TileDB-SingleCell/issues/10
+            # * https://github.com/TileDB-Inc/TileDB-Py/pull/1055
+            num_rows = len(A[:][self.dim_name].tolist())
+            num_cols = A.schema.nattr
+            return (num_rows, num_cols)
+
+    # ----------------------------------------------------------------
     def dim_select(self, ids):
         """
         Selects a slice out of the array with specified `obs_ids` (for `obsm` elements) or

--- a/apis/python/src/tiledbsc/annotation_matrix.py
+++ b/apis/python/src/tiledbsc/annotation_matrix.py
@@ -36,6 +36,8 @@ class AnnotationMatrix(TileDBArray):
         Returns a tuple with the number of rows and number of columns of the `AnnotationMatrix`.
         The row-count is the number of obs_ids (for `obsm` elements) or the number of var_ids (for
         `varm` elements).  The column-count is the number of columns/attributes in the dataframe.
+
+        Note: currently implemented via data scan -- will be optimized for TileDB core 2.10.
         """
         with self._open() as A:
             # These TileDB arrays are string-dimensioned sparse arrays so there is no '.shape'.

--- a/apis/python/src/tiledbsc/annotation_pairwise_matrix_group.py
+++ b/apis/python/src/tiledbsc/annotation_pairwise_matrix_group.py
@@ -2,6 +2,7 @@ import tiledb
 from .soma_options import SOMAOptions
 from .tiledb_group import TileDBGroup
 from .assay_matrix import AssayMatrix
+from .annotation_dataframe import AnnotationDataFrame
 import tiledbsc.util as util
 
 import pandas as pd
@@ -18,15 +19,21 @@ class AnnotationPairwiseMatrixGroup(TileDBGroup):
 
     row_dim_name: str
     col_dim_name: str
+    row_dataframe: AnnotationDataFrame
+    col_dataframe: AnnotationDataFrame
 
     def __init__(
         self,
         uri: str,
         name: str,
+        row_dataframe: AnnotationDataFrame,  # Nominally a reference to soma.obs
+        col_dataframe: AnnotationDataFrame,  # Nominally a reference to soma.var
         parent: Optional[TileDBGroup] = None,
     ):
         """
         See the TileDBObject constructor.
+        See `AssayMatrix` for the rationale behind retaining references to the `row_dataframe` and
+        `col_dataframe` objects.
         """
         assert name in ["obsp", "varp"]
         super().__init__(uri=uri, name=name, parent=parent)
@@ -36,6 +43,8 @@ class AnnotationPairwiseMatrixGroup(TileDBGroup):
         else:
             self.row_dim_name = "var_id_i"
             self.col_dim_name = "var_id_j"
+        self.row_dataframe = row_dataframe
+        self.col_dataframe = col_dataframe
 
     # ----------------------------------------------------------------
     def keys(self):
@@ -57,6 +66,8 @@ class AnnotationPairwiseMatrixGroup(TileDBGroup):
                 name=name,
                 row_dim_name=self.row_dim_name,
                 col_dim_name=self.col_dim_name,
+                row_dataframe=self.row_dataframe,
+                col_dataframe=self.col_dataframe,
                 parent=self,
             )
             retval.append(matrix)
@@ -82,6 +93,8 @@ class AnnotationPairwiseMatrixGroup(TileDBGroup):
                 name=matrix_name,
                 row_dim_name=self.row_dim_name,
                 col_dim_name=self.col_dim_name,
+                row_dataframe=self.row_dataframe,
+                col_dataframe=self.col_dataframe,
                 parent=self,
             )
             annotation_pairwise_matrix.from_matrix_and_dim_values(
@@ -186,6 +199,8 @@ class AnnotationPairwiseMatrixGroup(TileDBGroup):
                 name=name,
                 row_dim_name=self.row_dim_name,
                 col_dim_name=self.col_dim_name,
+                row_dataframe=self.row_dataframe,
+                col_dataframe=self.col_dataframe,
                 parent=self,
             )
 

--- a/apis/python/src/tiledbsc/assay_matrix.py
+++ b/apis/python/src/tiledbsc/assay_matrix.py
@@ -3,6 +3,7 @@ from .soma_options import SOMAOptions
 from .tiledb_array import TileDBArray
 from .tiledb_group import TileDBGroup
 from .tiledb_object import TileDBObject
+from .annotation_dataframe import AnnotationDataFrame
 import tiledbsc.util as util
 
 import scipy
@@ -23,6 +24,8 @@ class AssayMatrix(TileDBArray):
     row_dim_name: str  # obs_id for X, obs_id_i for obsp; var_id_i for varp
     col_dim_name: str  # var_id for X, obs_id_j for obsp; var_id_j for varp
     attr_name: str
+    row_dataframe: AnnotationDataFrame
+    col_dataframe: AnnotationDataFrame
 
     # ----------------------------------------------------------------
     def __init__(
@@ -31,20 +34,44 @@ class AssayMatrix(TileDBArray):
         name: str,
         row_dim_name: str,
         col_dim_name: str,
+        row_dataframe: AnnotationDataFrame,  # Nominally a reference to soma.obs
+        col_dataframe: AnnotationDataFrame,  # Nominally a reference to soma.var
         parent: Optional[TileDBGroup] = None,
     ):
         """
         See the TileDBObject constructor.
+        The `row_dataframe` and `col_dataframe` are nominally:
+        * `soma.obs` and `soma.var`, for `soma.X.data`
+        * `soma.obs` and `soma.raw.var`, for `soma.raw.X.data`
+        * `soma.obs` and `soma.obs`, for `soma.obsp` elements
+        * `soma.var` and `soma.var`, for `soma.obsp` elements
+        References to these objects are kept solely for obtaining dim labels for metadata
+        acquisition at runtime (e.g. shape). We retain references to these objects, rather
+        than taking in actualized ID-lists here in the constructor, for two reasons:
+        * We need to be able to set up a SOMA to write to, before it's been populated.
+        * For reading from an already-populated SOMA, we wish to avoid cache-coherency issues.
         """
         super().__init__(uri=uri, name=name, parent=parent)
 
         self.row_dim_name = row_dim_name
         self.col_dim_name = col_dim_name
         self.attr_name = "value"
+        self.row_dataframe = row_dataframe
+        self.col_dataframe = col_dataframe
 
     # ----------------------------------------------------------------
-    # We don't have a .shape() method since X is sparse. One should
-    # instead use the row-counts for the soma's obs and var.
+    def shape(self):
+        """
+        Returns a tuple with the number of rows and number of columns of the `AssayMatrix`.
+        In TileDB storage, these are string-indexed sparse arrays for which no `.shape()` exists,
+        but, we draw from the appropriate `obs`, `var`, `raw/var`, etc. as appropriate for a given matrix.
+        """
+        with self._open() as A:
+            # These TileDB arrays are string-dimensioned sparse arrays so there is no '.shape'.
+            # Instead we compute it ourselves.  See also:
+            num_rows = self.row_dataframe.shape()[0]
+            num_cols = self.col_dataframe.shape()[0]
+            return (num_rows, num_cols)
 
     # ----------------------------------------------------------------
     def dim_select(self, obs_ids, var_ids):

--- a/apis/python/src/tiledbsc/assay_matrix.py
+++ b/apis/python/src/tiledbsc/assay_matrix.py
@@ -65,6 +65,8 @@ class AssayMatrix(TileDBArray):
         Returns a tuple with the number of rows and number of columns of the `AssayMatrix`.
         In TileDB storage, these are string-indexed sparse arrays for which no `.shape()` exists,
         but, we draw from the appropriate `obs`, `var`, `raw/var`, etc. as appropriate for a given matrix.
+
+        Note: currently implemented via data scan -- will be optimized for TileDB core 2.10.
         """
         with self._open() as A:
             # These TileDB arrays are string-dimensioned sparse arrays so there is no '.shape'.

--- a/apis/python/src/tiledbsc/assay_matrix_group.py
+++ b/apis/python/src/tiledbsc/assay_matrix_group.py
@@ -1,5 +1,6 @@
 import tiledb
 from .assay_matrix import AssayMatrix
+from .annotation_dataframe import AnnotationDataFrame
 from .tiledb_group import TileDBGroup
 from .soma_options import SOMAOptions
 
@@ -22,10 +23,14 @@ class AssayMatrixGroup(TileDBGroup):
         name: str,
         row_dim_name: str,  # obs_id for X, obs_id_i for obsp; var_id_i for varp
         col_dim_name: str,  # var_id for X, obs_id_j for obsp; var_id_j for varp
+        row_dataframe: AnnotationDataFrame,  # Nominally a reference to soma.obs
+        col_dataframe: AnnotationDataFrame,  # Nominally a reference to soma.var
         parent: Optional[TileDBGroup] = None,
     ):
         """
         See the TileDBObject constructor.
+        See `AssayMatrix` for the rationale behind retaining references to the `row_dataframe` and
+        `col_dataframe` objects.
         """
         super().__init__(uri=uri, name=name, parent=parent)
 
@@ -35,6 +40,8 @@ class AssayMatrixGroup(TileDBGroup):
             name="data",
             row_dim_name=row_dim_name,
             col_dim_name=col_dim_name,
+            row_dataframe=row_dataframe,
+            col_dataframe=col_dataframe,
             parent=self,
         )
 

--- a/apis/python/src/tiledbsc/raw_group.py
+++ b/apis/python/src/tiledbsc/raw_group.py
@@ -22,34 +22,44 @@ class RawGroup(TileDBGroup):
     var: AnnotationDataFrame
     varm: AnnotationMatrixGroup
     varp: AnnotationPairwiseMatrixGroup
+    parent_obs: AnnotationDataFrame
 
     def __init__(
         self,
         uri: str,
         name: str,
+        obs: AnnotationDataFrame,  # Nominally a reference to soma.obs
         parent: Optional[TileDBGroup] = None,
     ):
         """
         See the TileDBObject constructor.
+        See `AssayMatrix` for the rationale behind retaining a reference to the `parent_obs` object.
         """
         super().__init__(uri=uri, name=name, parent=parent)
+        self.parent_obs = obs
 
         X_uri = os.path.join(self.uri, "X")
         var_uri = os.path.join(self.uri, "var")
         varm_uri = os.path.join(self.uri, "varm")
         varp_uri = os.path.join(self.uri, "varp")
 
+        self.var = AnnotationDataFrame(uri=var_uri, name="var", parent=self)
         self.X = AssayMatrixGroup(
             uri=X_uri,
             name="X",
             row_dim_name="obs_id",
             col_dim_name="var_id",
-            parent=self,
+            row_dataframe=self.parent_obs,
+            col_dataframe=self.var,
+            parent=self.var,
         )
-        self.var = AnnotationDataFrame(uri=var_uri, name="var", parent=self)
         self.varm = AnnotationMatrixGroup(uri=varm_uri, name="varm", parent=self)
         self.varp = AnnotationPairwiseMatrixGroup(
-            uri=varp_uri, name="varp", parent=self
+            uri=varp_uri,
+            name="varp",
+            row_dataframe=self.var,
+            col_dataframe=self.var,
+            parent=self,
         )
 
     # ----------------------------------------------------------------

--- a/apis/python/src/tiledbsc/soma.py
+++ b/apis/python/src/tiledbsc/soma.py
@@ -92,24 +92,34 @@ class SOMA(TileDBGroup):
         raw_uri = os.path.join(self.uri, "raw")
         uns_uri = os.path.join(self.uri, "uns")
 
+        self.obs = AnnotationDataFrame(uri=obs_uri, name="obs", parent=self)
+        self.var = AnnotationDataFrame(uri=var_uri, name="var", parent=self)
         self.X = AssayMatrixGroup(
             uri=X_uri,
             name="X",
             row_dim_name="obs_id",
             col_dim_name="var_id",
+            row_dataframe=self.obs,
+            col_dataframe=self.var,
             parent=self,
         )
-        self.obs = AnnotationDataFrame(uri=obs_uri, name="obs", parent=self)
-        self.var = AnnotationDataFrame(uri=var_uri, name="var", parent=self)
         self.obsm = AnnotationMatrixGroup(uri=obsm_uri, name="obsm", parent=self)
         self.varm = AnnotationMatrixGroup(uri=varm_uri, name="varm", parent=self)
         self.obsp = AnnotationPairwiseMatrixGroup(
-            uri=obsp_uri, name="obsp", parent=self
+            uri=obsp_uri,
+            name="obsp",
+            row_dataframe=self.obs,
+            col_dataframe=self.obs,
+            parent=self,
         )
         self.varp = AnnotationPairwiseMatrixGroup(
-            uri=varp_uri, name="varp", parent=self
+            uri=varp_uri,
+            name="varp",
+            row_dataframe=self.var,
+            col_dataframe=self.var,
+            parent=self,
         )
-        self.raw = RawGroup(uri=raw_uri, name="raw", parent=self)
+        self.raw = RawGroup(uri=raw_uri, name="raw", obs=self.obs, parent=self)
         self.uns = UnsGroup(uri=uns_uri, name="uns", parent=self)
 
         # If URI is "/something/test1" then:

--- a/apis/python/tests/test_soma_group_indexing.py
+++ b/apis/python/tests/test_soma_group_indexing.py
@@ -53,6 +53,7 @@ def test_soma_group_indexing(h5ad_file):
     )
     assert set(soma.X._get_member_names()) == set(["data"])
     assert soma.X.data.dim_names() == ["obs_id", "var_id"]
+    assert soma.X.data.shape() == (80, 20)
 
     assert soma.obs.exists()
     assert soma.obs.dim_names() == ["obs_id"]
@@ -66,6 +67,7 @@ def test_soma_group_indexing(h5ad_file):
         "groups",
         "RNA_snn_res.1",
     ]
+    assert soma.obs.shape() == (80, 7)
     assert set(soma.obs.ids()) == set(
         [
             "AAATTCGAATCACG",
@@ -172,6 +174,7 @@ def test_soma_group_indexing(h5ad_file):
         "vst.variance.standardized",
         "vst.variable",
     ]
+    assert soma.var.shape() == (20, 5)
     assert set(soma.var.ids()) == set(
         [
             "AKR1C3",
@@ -213,6 +216,7 @@ def test_soma_group_indexing(h5ad_file):
     assert isinstance(soma.obsm["X_pca"], tiledbsc.AnnotationMatrix)
     assert soma.obsm["nonesuch"] is None
     assert soma.obsm["X_pca"].dim_names() == ["obs_id"]
+    assert soma.obsm["X_pca"].shape() == (80, 19)
     assert soma.obsm["X_pca"].df().shape == (80, 19)
     assert list(soma.obsm["X_pca"].df().dtypes) == [
         np.dtype("float64"),
@@ -242,10 +246,13 @@ def test_soma_group_indexing(h5ad_file):
     assert soma.varm["nonesuch"] is None
     assert soma.varm._get_member_names() == ["PCs"]
     assert soma.varm["PCs"].dim_names() == ["var_id"]
+    assert soma.varm["PCs"].shape() == (20, 19)
+    assert soma.varm["PCs"].df().shape == (20, 19)
 
     assert set(soma.obsp._get_member_names()) == set(["distances"])
     assert soma.obsp["distances"].exists()
     assert soma.obsp["distances"].dim_names() == ["obs_id_i", "obs_id_j"]
+    assert soma.obsp["distances"].shape() == (80, 80)
     assert isinstance(soma.obsp["distances"], tiledbsc.AssayMatrix)
 
     assert soma.varp["nonesuch"] is None


### PR DESCRIPTION
Context: #125 

Example:

```
import tiledbsc

soma = tiledbsc.SOMA('tiledb-data/pbmc3k_processed')

print(soma.X.data.shape())
print(soma.obs.shape())
print(soma.var.shape())
print(soma.obsm['X_pca'].shape())
print(soma.varm['PCs'].shape())
print(soma.obsp['distances'].shape())
print(soma.raw.X.data.shape())
print(soma.raw.var.shape())
```

```
(2638, 1838)
(2638, 4)
(1838, 1)
(2638, 50)
(1838, 50)
(2638, 2638)
(2638, 13714)
(13714, 1)
```