### PR TITLE
Use the public name for scipy.sparse.csr_matrix

### DIFF
--- a/apis/python/README-ingestion.md
+++ b/apis/python/README-ingestion.md
@@ -136,7 +136,7 @@ ANNDATA FILE TYPES:
 X/data                                   <class 'numpy.ndarray'>
 X/data shape                             (80, 20)
 X/data dtype                             float64
-X/raw                                    <class 'scipy.sparse._csr.csr_matrix'>
+X/raw                                    <class 'scipy.sparse.csr_matrix'>
 X/raw shape                              (80, 230)
 X/data dtype                             float64
 X/raw density                            0.2422
@@ -145,7 +145,7 @@ var                                      <class 'pandas.core.frame.DataFrame'>
 obsm/X_pca                               <class 'numpy.ndarray'>
 obsm/X_tsne                              <class 'numpy.ndarray'>
 varm/PCs                                 <class 'numpy.ndarray'>
-obsp/distances                           <class 'scipy.sparse._csr.csr_matrix'>
+obsp/distances                           <class 'scipy.sparse.csr_matrix'>
 uns/neighbors/params/method              (1,) <class 'numpy.ndarray'> object
 ```
 

--- a/apis/python/src/tiledbsc/assay_matrix.py
+++ b/apis/python/src/tiledbsc/assay_matrix.py
@@ -176,7 +176,7 @@ class AssayMatrix(TileDBArray):
     # ----------------------------------------------------------------
     def _ingest_data(self, matrix, row_names, col_names) -> None:
         if self._soma_options.write_X_chunked:
-            if isinstance(matrix, scipy.sparse._csr.csr_matrix):
+            if isinstance(matrix, scipy.sparse.csr_matrix):
                 self.ingest_data_rows_chunked(matrix, row_names, col_names)
             elif isinstance(matrix, scipy.sparse._csc.csc_matrix):
                 self.ingest_data_cols_chunked(matrix, row_names, col_names)

--- a/apis/python/src/tiledbsc/util.py
+++ b/apis/python/src/tiledbsc/util.py
@@ -29,7 +29,7 @@ def format_elapsed(start_stamp, message: str):
 
 # ----------------------------------------------------------------
 def _find_csr_chunk_size(
-    mat: scipy.sparse._csr.csr_matrix,
+    mat: scipy.sparse.csr_matrix,
     permutation: list,
     start_row_index: int,
     goal_chunk_nnz: int,

--- a/apis/python/src/tiledbsc/util_ann.py
+++ b/apis/python/src/tiledbsc/util_ann.py
@@ -83,7 +83,7 @@ def _describe_ann_file_show_types(anndata: ad.AnnData, input_path: str):
     m, n = X.shape
     print("%-*s (%d, %d)" % (namewidth, "X/data shape", m, n))
     print("%-*s %s" % (namewidth, "X/data dtype", X.dtype))
-    if isinstance(X, (scipy.sparse._csr.csr_matrix, scipy.sparse._csc.csc_matrix)):
+    if isinstance(X, (scipy.sparse.csr_matrix, scipy.sparse._csc.csc_matrix)):
         density = X.nnz / (m * n)
         print("%-*s %.4f" % (namewidth, "X/data density", density))
 
@@ -100,7 +100,7 @@ def _describe_ann_file_show_types(anndata: ad.AnnData, input_path: str):
         m, n = X.shape
         print("%-*s (%d, %d)" % (namewidth, "X/raw shape", m, n))
         print("%-*s %s" % (namewidth, "X/data dtype", X.dtype))
-        if isinstance(X, (scipy.sparse._csr.csr_matrix, scipy.sparse._csc.csc_matrix)):
+        if isinstance(X, (scipy.sparse.csr_matrix, scipy.sparse._csc.csc_matrix)):
             density = X.nnz / (m * n)
             print("%-*s %.4f" % (namewidth, "X/raw density", density))
 


### PR DESCRIPTION
When originally coding the ingestor for this package, at the Python REPL I asked some `anndata` slot for its `type` and what came back was `scipy.sparse._csr.csr_matrix` -- so I shrugged, typed that in, and continued.

This is an internal name; it's better to use `scipy.sparse.csr_matrix`.

This is an ask from one of our early kick-the-tires users.