### PR TITLE
Write SOMA object type as group/array metadata

### DIFF
--- a/apis/python/src/tiledbsc/annotation_dataframe.py
+++ b/apis/python/src/tiledbsc/annotation_dataframe.py
@@ -189,6 +189,8 @@ class AnnotationDataFrame(TileDBArray):
             mode=mode,
         )
 
+        self.set_soma_object_type_metadata()
+
         if self._verbose:
             print(util.format_elapsed(s, f"{self._indent}FINISH WRITING {self.uri}"))
 

--- a/apis/python/src/tiledbsc/annotation_matrix.py
+++ b/apis/python/src/tiledbsc/annotation_matrix.py
@@ -105,6 +105,8 @@ class AnnotationMatrix(TileDBArray):
         else:
             self._numpy_ndarray_or_scipy_sparse_csr_matrix(matrix, dim_values)
 
+        self.set_soma_object_type_metadata()
+
         if self._verbose:
             print(util.format_elapsed(s, f"{self._indent}FINISH WRITING {self.uri}"))
 

--- a/apis/python/src/tiledbsc/assay_matrix.py
+++ b/apis/python/src/tiledbsc/assay_matrix.py
@@ -121,6 +121,8 @@ class AssayMatrix(TileDBArray):
         else:
             self._create_empty_array(matrix_dtype=matrix.dtype)
 
+        self.set_soma_object_type_metadata()
+
         self._ingest_data(matrix, row_names, col_names)
         if self._verbose:
             print(util.format_elapsed(s, f"{self._indent}FINISH WRITING {self.uri}"))

--- a/apis/python/src/tiledbsc/tiledb_array.py
+++ b/apis/python/src/tiledbsc/tiledb_array.py
@@ -1,4 +1,5 @@
 import tiledb
+import tiledbsc.util_tiledb
 from .soma_options import SOMAOptions
 from .tiledb_object import TileDBObject
 from .tiledb_group import TileDBGroup
@@ -96,3 +97,13 @@ class TileDBArray(TileDBObject):
         Returns true if the array has the specified attribute name, false otherwise.
         """
         return attr_name in self.attr_names()
+
+    def set_soma_object_type_metadata(self) -> None:
+        """
+        This helps nested-structured traversals (especially those that start at the SOMACollection
+        level) confidently navigate with a minimum of introspection on group contents.
+        """
+        with self._open("w") as A:
+            A.meta[
+                tiledbsc.util_tiledb.SOMA_OBJECT_TYPE_METADATA_KEY
+            ] = self.__class__.__name__

--- a/apis/python/src/tiledbsc/tiledb_group.py
+++ b/apis/python/src/tiledbsc/tiledb_group.py
@@ -1,4 +1,5 @@
 import tiledb
+import tiledbsc.util_tiledb
 from .soma_options import SOMAOptions
 from .tiledb_object import TileDBObject
 
@@ -60,6 +61,10 @@ class TileDBGroup(TileDBObject):
         if self._verbose:
             print(f"{self._indent}Creating TileDB group {self.uri}")
         tiledb.group_create(uri=self.uri, ctx=self._ctx)
+        with self._open("w") as G:
+            G.meta[
+                tiledbsc.util_tiledb.SOMA_OBJECT_TYPE_METADATA_KEY
+            ] = self.__class__.__name__
 
     def _open_withlessly(self, mode="r"):
         """

--- a/apis/python/src/tiledbsc/util_tiledb.py
+++ b/apis/python/src/tiledbsc/util_tiledb.py
@@ -4,6 +4,11 @@ import sys, os
 import tiledb
 from typing import Optional
 
+# This is for group/array metadata we write, to help nested-structured traversals (especially those
+# that start at the SOMACollection level) confidently navigate with a minimum of introspection on
+# group contents.
+SOMA_OBJECT_TYPE_METADATA_KEY = "__soma_object_type__"
+
 # ================================================================
 def show_single_cell_group(soma_uri: str, ctx: Optional[tiledb.Ctx] = None):
     """

--- a/apis/python/tests/test_soco_ops.py
+++ b/apis/python/tests/test_soco_ops.py
@@ -28,6 +28,13 @@ def test_import_anndata(tmp_path):
 
     soco = tiledbsc.SOMACollection(soco_dir)
 
+    # TODO: change this to with-open-as syntax once
+    # https://github.com/TileDB-Inc/TileDB-Py/pull/1124
+    # is in a TileDB-Py release which we articulate a dependency on.
+    G = tiledb.Group(soma1_dir)
+    assert G.meta[tiledbsc.util_tiledb.SOMA_OBJECT_TYPE_METADATA_KEY] == "SOMA"
+    G.close()
+
     soco._create()
     assert len(soco._get_member_names()) == 0
 


### PR DESCRIPTION
This will be useful for tree-traversal in the C++ implementation, as well as for Python/R compatibility checks.

Example (in addition to unit-test cases on this PR):

```
$ ingestor anndata/pbmc-small.h5ad tiledb-data/pbmc-small
...
```

```
$ populate-soco -o soco -a tiledb-data/pbmc-small
Adding pbmc-small to tiledb-data/pbmc-small
Creating TileDB group soco
```

```
$ python

>>> import tiledb

>>> A = tiledb.open('tiledb-data/pbmc-small/X/data')
>>> A.meta['__soma_object_type__']
'AssayMatrix'
>>> A.close()

>>> G = tiledb.group.Group('tiledb-data/pbmc-small/X')
>>> G.meta
<tiledb.group.Group.GroupMetadata object at 0x7f9e51e79f70>
>>> G.meta['__soma_object_type__']
'AssayMatrixGroup'
>>> G.close()

>>> G = tiledb.group.Group('tiledb-data/pbmc-small')
>>> G.meta['__soma_object_type__']
'SOMA'
>>> G.close()

>>> G = tiledb.group.Group('soco')
>>> G.meta['__soma_object_type__']
'SOMACollection'
>>> G.close()
```