### PR TITLE
Extend ASCII-queryability workaround

### DIFF
--- a/apis/python/src/tiledbsc/soma_options.py
+++ b/apis/python/src/tiledbsc/soma_options.py
@@ -1,33 +1,5 @@
 from typing import List, Dict
 
-# TODO: when UTF-8 attributes are queryable using TileDB-Py's QueryCondition API we can remove this.
-# Context: https://github.com/single-cell-data/TileDB-SingleCell/issues/99.
-default_col_names_to_store_as_ascii = {
-    "obs": [
-        "assay_ontology_term_id",
-        "sex_ontology_term_id",
-        "organism_ontology_term_id",
-        "disease_ontology_term_id",
-        "ethnicity_ontology_term_id",
-        "development_stage_ontology_term_id",
-        "cell_type_ontology_term_id",
-        "tissue_ontology_term_id",
-        "cell_type",
-        "assay",
-        "disease",
-        "organism",
-        "sex",
-        "tissue",
-        "ethnicity",
-        "development_stage",
-    ],
-    "var": [
-        "feature_biotype",
-        "feature_name",
-        "feature_reference",
-    ],
-}
-
 
 class SOMAOptions:
     """
@@ -45,7 +17,6 @@ class SOMAOptions:
     string_dim_zstd_level: int
     write_X_chunked: bool
     goal_chunk_nnz: int
-    col_names_to_store_as_ascii: Dict[str, List[str]]
     member_uris_are_relative: bool
 
     def __init__(
@@ -58,7 +29,6 @@ class SOMAOptions:
         string_dim_zstd_level=22,  # https://github.com/single-cell-data/TileDB-SingleCell/issues/27
         write_X_chunked=True,
         goal_chunk_nnz=10000000,
-        col_names_to_store_as_ascii=default_col_names_to_store_as_ascii,
         member_uris_are_relative=None,  # Allows relocatability for local disk / S3, and correct behavior for TileDB Cloud
     ):
         self.obs_extent = obs_extent
@@ -69,5 +39,4 @@ class SOMAOptions:
         self.string_dim_zstd_level = string_dim_zstd_level
         self.write_X_chunked = write_X_chunked
         self.goal_chunk_nnz = goal_chunk_nnz
-        self.col_names_to_store_as_ascii = col_names_to_store_as_ascii
         self.member_uris_are_relative = member_uris_are_relative

--- a/apis/python/tests/test_type_diversity.py
+++ b/apis/python/tests/test_type_diversity.py
@@ -70,11 +70,6 @@ def test_from_anndata_X_type(tmp_path, X_dtype_name, X_encoding):
         assert False  # sanity - test misconfiguration
 
     adata = ad.AnnData(X=X, obs=obs, var=var, dtype=X.dtype)
-    print(
-        " =============================================================>==",
-        adata.X.dtype,
-        X_dtype,
-    )
     assert adata.X.dtype == X_dtype  # sanity
 
     io.from_anndata(SOMA(tmp_path.as_posix()), adata)
@@ -180,6 +175,10 @@ def test_from_anndata_DataFrame_type(tmp_path):
         # TileDB has no object, so assume it will convert to the type underlying the object
         if ad_dtype == np.dtype("O"):
             ad_dtype = np.dtype(type(series[0]))
+            # TODO: see annotation_dataframe.py. Once Unicode attributes are queryable, we'll need
+            # to remove this check which is verifying the current force-to-ASCII workaround.
+            if ad_dtype.name == "str":
+                ad_dtype = np.dtype("S")
         # TileDB has no bool, and automatically converts to uint8
         if ad_dtype == bool:
             ad_dtype = np.uint8

--- a/apis/python/tools/peek-ann
+++ b/apis/python/tools/peek-ann
@@ -30,6 +30,9 @@ else:
 
 ann = anndata.read_h5ad(input_path)
 
+def decat(ann):
+    return tiledbsc.util_ann._decategoricalize(ann)
+
 # Interact at the prompt now:
 # * ann.X
 # * ann.obs.keys()


### PR DESCRIPTION
Context: issue #99. (See also: issue #106 and PRs #101 and #117.)

As pointed out by @bkmartinjr in a Slack conversation, the selection of string columns to store as ASCII on #101 was artificial, and likely to cause confusion. The better approach he suggested was to do this to _all_ string attributes.

This PR implements that better approach.

We will need this store-as-ASCII, decode-to-Unicode on read workaround for a couple months or so now pending some non-trivial work in TileDB core to fully support `QueryCondition` logic on Unicode attributes. As a reminder on the important of this workaround, string attributes are _non-queryable_ unless they are stored as ASCII, until full core-level support is in place; cc @Shelnutt2 and @ihnorton.

Note for @ebezzi and @bkmartinjr -- we will need a full re-ingest once this is merged and once https://github.com/TileDB-Inc/TileDB-Py/pull/1110 is merged and deployed in a `TileDB-Py` release which we include here in `tiledbsc-py`.