### PR TITLE
Group-names readback

### DIFF
--- a/apis/python/src/tiledbsc/tiledb_group.py
+++ b/apis/python/src/tiledbsc/tiledb_group.py
@@ -152,4 +152,10 @@ class TileDBGroup(TileDBObject):
         member name to member URI.
         """
         with self._open("r") as G:
-            return {os.path.basename(e.uri): e.uri for e in G}
+
+            # We aren't able to get a listing of group keys, so as a workaround we parse the group printer.
+            names = [
+                e.split()[1] for e in G.__repr__().split("\n") if e.startswith("|-- ")
+            ]
+
+            return {name: G[name].uri for name in names}


### PR DESCRIPTION
At the moment we can't read back group-element names from the TileDB Group API. Previously I worked around this by taking basename of element URI and calling that "name" but this isn't a good heuristic in cases like this:

```
/Users/johnkerl/mini-corpus/tiledb-data-seurat/adipocytes-seurat/soma_RNA"
/Users/johnkerl/mini-corpus/tiledb-data-seurat/wilms-tumors-seurat/soma_RNA"
```

as these have the same basename.

On this PR is a better way to get the names these were added with.

On an upcoming TileDB-Py release we'll have direct TileDB-API support for this.