### PR TITLE
Correct ASCII-to-Unicode readback for attribute_filter

### DIFF
--- a/apis/python/src/tiledbsc/annotation_dataframe.py
+++ b/apis/python/src/tiledbsc/annotation_dataframe.py
@@ -89,12 +89,7 @@ class AnnotationDataFrame(TileDBArray):
         # TODO: when UTF-8 attributes are queryable using TileDB-Py's QueryCondition API we can remove this.
         # This is the 'decode on read' part of our logic; in dim_select we have the 'encode on write' part.
         # Context: https://github.com/single-cell-data/TileDB-SingleCell/issues/99.
-        for k in df:
-            dfk = df[k]
-            if len(dfk) > 0 and type(dfk[0]) == bytes:
-                df[k] = dfk.map(lambda e: e.decode())
-
-        return df
+        return self._ascii_to_unicode_dataframe_readback(df)
 
     # ----------------------------------------------------------------
     def df(self, ids=None) -> pd.DataFrame:
@@ -120,7 +115,20 @@ class AnnotationDataFrame(TileDBArray):
             if nobs == 0:
                 return None
             else:
-                return slice_df
+                # This is the 'decode on read' part of our logic; in dim_select we have the 'encode on write' part.
+                # Context: https://github.com/single-cell-data/TileDB-SingleCell/issues/99.
+                return self._ascii_to_unicode_dataframe_readback(slice_df)
+
+    # ----------------------------------------------------------------
+    def _ascii_to_unicode_dataframe_readback(self, df):
+        """
+        Implements the 'decode on read' partof our logic as noted in `dim_select()`.
+        """
+        for k in df:
+            dfk = df[k]
+            if len(dfk) > 0 and type(dfk[0]) == bytes:
+                df[k] = dfk.map(lambda e: e.decode())
+        return df
 
     # ----------------------------------------------------------------
     def from_dataframe(self, dataframe: pd.DataFrame, extent: int) -> None:

--- a/apis/python/tests/test_ascii_and_unicode.py
+++ b/apis/python/tests/test_ascii_and_unicode.py
@@ -1,0 +1,84 @@
+import anndata as ad
+import tiledb
+from tiledbsc import SOMA
+import tiledbsc.io as io
+import pandas as pd
+import numpy as np
+from scipy import sparse
+
+from pathlib import Path
+
+import pytest
+
+
+def test_readback(tmp_path):
+    """
+    Validate correct encode/decode of non-ASCII attribute text.
+    """
+    obs_ids = [
+        "AAATTCGAATCACG",
+        "AATGTTGACAGTCA",
+        "AGAGATGATCTCGC",
+        "CATGGCCTGTGCAT",
+        "CCCAACTGCAATCG",
+        "CTAACGGAACCGAT",
+        "GAACCTGATGAACC",
+        "GCGTAAACACGGTT",
+        "TTACCATGAATCGC",
+        "TTACGTACGTTCAG",
+    ]
+
+    var_ids = [
+        "AKR1C3",
+        "CA2",
+        "CD1C",
+        "HLA-DPB1",
+        "IGLL5",
+        "PARVB",
+        "PGRMC1",
+        "RP11-290F20.3",
+        "SDPR",
+    ]
+
+    n_obs = len(obs_ids)
+    n_var = len(var_ids)
+
+    cell_types = ["blööd" if obs_id[1] == "A" else "lung" for obs_id in obs_ids]
+    feature_names = [
+        "ENSG00000999999" if var_id[1] < "M" else "ENSG00000123456"
+        for var_id in var_ids
+    ]
+
+    obs = pd.DataFrame(
+        data={
+            "obs_id": np.asarray(obs_ids),
+            "cell_type": np.asarray(cell_types),
+        },
+        index=np.arange(n_obs).astype(str),
+    )
+    obs.set_index("obs_id", inplace=True)
+    var = pd.DataFrame(
+        data={
+            "var_id": np.asarray(var_ids),
+            "feature_name": np.asarray(feature_names),
+        },
+        index=np.arange(n_var).astype(str),
+    )
+    var.set_index("var_id", inplace=True)
+
+    X = np.eye(n_obs, n_var)
+
+    adata = ad.AnnData(X=X, obs=obs, var=var, dtype=X.dtype)
+
+    soma = SOMA(tmp_path.as_posix())
+
+    io.from_anndata(soma, adata)
+
+    assert (
+        len(soma.obs.attribute_filter('cell_type=="lung"', ["cell_type"])["cell_type"])
+        == 6
+    )
+    assert (
+        len(soma.obs.attribute_filter('cell_type=="blööd"', ["cell_type"])["cell_type"])
+        == 4
+    )


### PR DESCRIPTION
Context: #106 

See also: #138 #101 #99

The idea is that:

* For the next few months, pending an upcoming TileDB-core release, we'll be taking `obs`/`var` Unicode strings and storing them as "ASCII" which really means bytes -- "α,β,γ" stores as "\xce\xb1,\xce\xb2,\xce\xb3"
* On readback of `obs`/`var` dataframes we decode back to "α,β,γ"
* This was being done correctly on the `AnnotationDataFrame`'s `dim_select` / `df` accessor; the same logic needs applied to its `attribute_filter` accessor