### PR TITLE
Add spdlog to C++ API

### DIFF
--- a/libtiledbsc/cmake/Modules/FindSpdlog_EP.cmake
+++ b/libtiledbsc/cmake/Modules/FindSpdlog_EP.cmake
@@ -46,11 +46,17 @@ else()
   SET(SPDLOG_NO_DEFAULT_PATH)
 endif()
 
-find_package(spdlog
+# Fix issue on windows where spdlog::spdlog is already defined
+if (NOT TARGET spdlog::spdlog)
+  find_package(spdlog
         PATHS ${EP_INSTALL_PREFIX}
         ${SPDLOG_NO_DEFAULT_PATH}
         )
-set(SPDLOG_FOUND ${spdlog_FOUND})
+  set(SPDLOG_FOUND ${spdlog_FOUND})
+else()
+  message(STATUS "TARGET spdlog::spdlog already defined. (Windows?)")
+  set(SPDLOG_FOUND TRUE)
+endif()
 
 if (NOT SPDLOG_FOUND)
   if(SUPERBUILD)
@@ -73,8 +79,11 @@ if (NOT SPDLOG_FOUND)
       PREFIX "externals"
       # Set download name to avoid collisions with only the version number in the filename
       DOWNLOAD_NAME ep_spdlog.zip
-      URL "https://github.com/gabime/spdlog/archive/v1.10.0.zip"
-      URL_HASH SHA1=aa2d4ff13b5393dea83d46caf545c6a303c889cd
+      URL "https://github.com/gabime/spdlog/archive/v1.9.0.zip"
+      URL_HASH SHA1=6259d1b6c5b9b565aa3ba5a6315d49f76d90ec0a
+# TODO: upgrade requires logger changes
+#      URL "https://github.com/gabime/spdlog/archive/v1.10.0.zip"
+#      URL_HASH SHA1=aa2d4ff13b5393dea83d46caf545c6a303c889cd
       PATCH_COMMAND
         ${CONDITIONAL_PATCH}
       CMAKE_ARGS

--- a/libtiledbsc/cmake/Superbuild.cmake
+++ b/libtiledbsc/cmake/Superbuild.cmake
@@ -72,7 +72,7 @@ set(INHERITED_CMAKE_ARGS
 #TBD include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/Modules/FindCLI11_EP.cmake)
 include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/Modules/FindTileDB_EP.cmake)
 # include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/Modules/FindCatch_EP.cmake)
-# include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/Modules/FindSpdlog_EP.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/Modules/FindSpdlog_EP.cmake)
 
 ############################################################
 # 'make format' target

--- a/libtiledbsc/include/tiledbsc/logger_private.h
+++ b/libtiledbsc/include/tiledbsc/logger_private.h
@@ -1,0 +1,115 @@
+/**
+ * @file   logger_private.h
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2017-2022 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This file defines simple logging functions that *cannot* be exposed to the
+ * public API. Their implementations are in `logger.cc`. See the documentation
+ * in `logger.h` for the full story.
+ */
+
+#pragma once
+#ifndef TILEDB_LOGGER_PRIVATE_H
+#define TILEDB_LOGGER_PRIVATE_H
+
+#include "logger.h"
+
+namespace tiledbsc {
+
+/** Set log level for global logger and optionally set a logfile. */
+void LOG_CONFIG(const std::string& level, const std::string& logfile = "");
+
+/** Set log level for global logger. */
+void LOG_SET_LEVEL(const std::string& level);
+
+/** Set log file for global logger. */
+void LOG_SET_FILE(const std::string& logfile);
+
+/** Check if global logger is logging debug messages. */
+bool LOG_DEBUG_ENABLED();
+
+/** Logs a trace message. */
+void LOG_TRACE(const std::string& msg);
+
+/** Logs a formatted trace message. */
+template <typename Arg1, typename... Args>
+void LOG_TRACE(const char* fmt, const Arg1& arg1, const Args&... args) {
+    global_logger().trace(fmt, arg1, args...);
+}
+
+/** Logs a debug message. */
+void LOG_DEBUG(const std::string& msg);
+
+/** Logs a formatted debug message. */
+template <typename Arg1, typename... Args>
+void LOG_DEBUG(const char* fmt, const Arg1& arg1, const Args&... args) {
+    global_logger().debug(fmt, arg1, args...);
+}
+
+/** Logs an info message. */
+void LOG_INFO(const std::string& msg);
+
+/** Logs a formatted info message. */
+template <typename Arg1, typename... Args>
+void LOG_INFO(const char* fmt, const Arg1& arg1, const Args&... args) {
+    global_logger().info(fmt, arg1, args...);
+}
+
+/** Logs a warning. */
+void LOG_WARN(const std::string& msg);
+
+/** Logs a formatted warning message. */
+template <typename Arg1, typename... Args>
+void LOG_WARN(const char* fmt, const Arg1& arg1, const Args&... args) {
+    global_logger().warn(fmt, arg1, args...);
+}
+
+/** Logs an error. */
+void LOG_ERROR(const std::string& msg);
+
+/** Logs a formatted error message. */
+template <typename Arg1, typename... Args>
+void LOG_ERROR(const char* fmt, const Arg1& arg1, const Args&... args) {
+    global_logger().error(fmt, arg1, args...);
+}
+
+/** Logs a critical error and exits with a non-zero status. */
+void LOG_FATAL(const std::string& msg);
+
+/** Logs a formatted critical error and exits with a non-zero status. */
+template <typename Arg1, typename... Args>
+void LOG_FATAL(const char* fmt, const Arg1& arg1, const Args&... args) {
+    global_logger().critical(fmt, arg1, args...);
+    exit(1);
+}
+
+/** Convert TileDB timestamp (in ms) to human readable timestamp. */
+std::string asc_timestamp(uint64_t timestamp_ms);
+
+}  // namespace tiledbsc
+
+#endif

--- a/libtiledbsc/include/tiledbsc/logger_public.h
+++ b/libtiledbsc/include/tiledbsc/logger_public.h
@@ -1,0 +1,78 @@
+/**
+ * @file   logger_public.h
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2017-2021 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This file defines simple logging functions that can be exposed (by expedient)
+ * to the public API. Their implementations are in `logger.cc`. See the
+ * documentation in `logger.h` for the full story.
+ */
+
+#pragma once
+#ifndef TILEDB_LOGGER_PUBLIC_H
+#define TILEDB_LOGGER_PUBLIC_H
+
+#include "logger.h"
+
+namespace tiledbsc {
+
+/** Set log level for global logger and optionally set a logfile. */
+void LOG_CONFIG(const std::string& level, const std::string& logfile = "");
+
+/** Set log level for global logger. */
+void LOG_SET_LEVEL(const std::string& level);
+
+/** Set log file for global logger. */
+void LOG_SET_FILE(const std::string& logfile);
+
+/** Check if global logger is logging debug messages. */
+bool LOG_DEBUG_ENABLED();
+
+/** Logs a trace message. */
+void LOG_TRACE(const std::string& msg);
+
+/** Logs a debug message. */
+void LOG_DEBUG(const std::string& msg);
+
+/** Logs an info message. */
+void LOG_INFO(const std::string& msg);
+
+/** Logs a warning. */
+void LOG_WARN(const std::string& msg);
+
+/** Logs an error. */
+void LOG_ERROR(const std::string& msg);
+
+/** Logs a critical error and exits with a non-zero status. */
+void LOG_FATAL(const std::string& msg);
+
+/** Convert TileDB timestamp (in ms) to human readable timestamp. */
+std::string asc_timestamp(uint64_t timestamp_ms);
+
+}  // namespace tiledbsc
+
+#endif  // TILEDB_LOGGER_PUBLIC_H

--- a/libtiledbsc/src/CMakeLists.txt
+++ b/libtiledbsc/src/CMakeLists.txt
@@ -7,7 +7,7 @@ set(CMAKE_WARN_DEPRECATED OFF CACHE BOOL "" FORCE)
 ############################################################
 
 find_package(TileDB_EP REQUIRED)
-# find_package(Spdlog_EP REQUIRED)
+find_package(Spdlog_EP REQUIRED)
 
 ############################################################
 # Get source commit hash
@@ -49,6 +49,7 @@ add_library(TILEDB_SC_OBJECTS OBJECT
   ${CMAKE_CURRENT_SOURCE_DIR}/util.cc
   ${CMAKE_CURRENT_SOURCE_DIR}/soma.cc
   ${CMAKE_CURRENT_SOURCE_DIR}/soma_collection.cc
+  ${CMAKE_CURRENT_SOURCE_DIR}/logger.cc
 )
 
 message(WARNING "Building without deprecation warnings")
@@ -68,7 +69,7 @@ target_include_directories(TILEDB_SC_OBJECTS
     ${CMAKE_CURRENT_SOURCE_DIR}
     ${CMAKE_CURRENT_SOURCE_DIR}/../include
     $<TARGET_PROPERTY:TileDB::tiledb_shared,INTERFACE_INCLUDE_DIRECTORIES>
-#    $<TARGET_PROPERTY:spdlog::spdlog,INTERFACE_INCLUDE_DIRECTORIES>
+    $<TARGET_PROPERTY:spdlog::spdlog,INTERFACE_INCLUDE_DIRECTORIES>
 )
 
 ############################################################
@@ -116,7 +117,7 @@ add_library(tiledbsc SHARED
 target_link_libraries(tiledbsc
   PUBLIC
     TileDB::tiledb_shared
-    # TBD spdlog::spdlog
+    spdlog::spdlog
 )
 
 # Sanitizer linker flags
@@ -184,7 +185,7 @@ target_link_libraries(tiledbsc-bin
 target_link_libraries(tiledbsc-bin
   PUBLIC
     #CLI11::CLI11
-    # spdlog::spdlog
+    spdlog::spdlog
     tiledbsc
     TileDB::tiledb_shared
 )

--- a/libtiledbsc/src/cli/cli.cc
+++ b/libtiledbsc/src/cli/cli.cc
@@ -1,6 +1,7 @@
 // TODO fixes build error on VS2019 due to "missing" include in <tiledb/type.h>
 #include <stdexcept>
 
+#include <tiledbsc/logger_private.h>
 #include <tiledbsc/soma.h>
 #include <tiledbsc/soma_collection.h>
 #include <tiledbsc/tiledbsc.h>
@@ -11,13 +12,15 @@ void walk_soco(std::string_view uri) {
     auto soco = SOMACollection::open(uri);
     auto somas = soco.list_somas();
 
+    LOG_INFO("walking soco URI = '{}'", uri);
+
     for (auto& [name, uri] : somas) {
-        printf("soma %s = %s\n", name.c_str(), uri.c_str());
+        LOG_INFO("  soma {} = {}", name, uri);
 
         auto soma = SOMA::open(uri);
         auto arrays = soma.list_arrays();
         for (auto& [name, uri] : arrays) {
-            printf("  array %s = %s\n", name.c_str(), uri.c_str());
+            LOG_INFO("    array {} = {}", name, uri);
         }
     }
 }
@@ -28,10 +31,12 @@ int main(int argc, char** argv) {
         return 1;
     }
 
+    LOG_CONFIG("debug");
+
     try {
         walk_soco(argv[1]);
     } catch (const std::exception& e) {
-        printf("ERROR: %s\n", e.what());
+        LOG_FATAL("URI '{}' is not a SOMACollection. {}", argv[1], e.what());
     }
 
     return 0;

--- a/libtiledbsc/src/logger.cc
+++ b/libtiledbsc/src/logger.cc
@@ -1,0 +1,237 @@
+/**
+ * @file   logger.cc
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2017-2021 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This file defines class Logger, declared in logger.h, and the public logging
+ * functions, declared in logger_public.h.
+ */
+
+#include "logger.h"
+
+#include <spdlog/fmt/fmt.h>
+#include <spdlog/fmt/ostr.h>
+#include <spdlog/sinks/basic_file_sink.h>
+#include <spdlog/sinks/stdout_color_sinks.h>
+
+namespace tiledbsc {
+
+// Set the default logging format
+// %^ : start color range
+// [Year-month-day 24hr-min-second.microsecond]
+// [logger]
+// [Process: id]
+// [Thread: id]
+// [log level]
+// text to log...
+// %$ : end color range
+const std::string LOG_PATTERN =
+    "%^[%Y-%m-%d %H:%M:%S.%e] [%n] [Process: %P] [Thread: %t] [%l] %v%$";
+const std::string CONSOLE_LOGGER = "tiledbsc";
+const std::string FILE_LOGGER = "tiledbsc-file";
+
+/* ********************************* */
+/*     CONSTRUCTORS & DESTRUCTORS    */
+/* ********************************* */
+
+Logger::Logger() {
+    logger_ = spdlog::get(CONSOLE_LOGGER);
+    if (logger_ == nullptr) {
+        logger_ = spdlog::stdout_color_mt(CONSOLE_LOGGER);
+#ifndef _WIN32
+        // change color of critical messages
+        auto console_sink = static_cast<spdlog::sinks::stdout_color_sink_mt*>(
+            logger_->sinks().back().get());
+        console_sink->set_color(
+            spdlog::level::critical, console_sink->red_bold);
+#endif
+    }
+    logger_->set_pattern(LOG_PATTERN);
+    set_level("FATAL");
+}
+
+Logger::~Logger() {
+    spdlog::drop(CONSOLE_LOGGER);
+    if (spdlog::get(FILE_LOGGER) != nullptr) {
+        spdlog::drop(FILE_LOGGER);
+    }
+}
+
+void Logger::trace(const char* msg) {
+    logger_->trace(msg);
+}
+
+void Logger::debug(const char* msg) {
+    logger_->debug(msg);
+}
+
+void Logger::info(const char* msg) {
+    logger_->info(msg);
+}
+
+void Logger::warn(const char* msg) {
+    logger_->warn(msg);
+}
+
+void Logger::error(const char* msg) {
+    logger_->error(msg);
+}
+
+void Logger::critical(const char* msg) {
+    logger_->critical(msg);
+}
+
+void Logger::set_level(const std::string& level_in) {
+    // convert level to lower case
+    std::string level = level_in;
+    std::for_each(
+        level.begin(), level.end(), [](char& c) { c = ::tolower(c); });
+
+    if (level == "fatal" || level[0] == 'f') {
+        level_ = spdlog::level::critical;
+    } else if (level == "error" || level[0] == 'e') {
+        level_ = spdlog::level::err;
+    } else if (level == "warn" || level[0] == 'w') {
+        level_ = spdlog::level::warn;
+    } else if (level == "info" || level[0] == 'i') {
+        level_ = spdlog::level::info;
+    } else if (level == "debug" || level[0] == 'd') {
+        level_ = spdlog::level::debug;
+    } else if (level == "trace" || level[0] == 't') {
+        level_ = spdlog::level::trace;
+    } else {
+        set_level("WARN");
+        //        LOG_WARN("Illegal log level = {}, using log level FATAL",
+        //        level);
+        level_ = spdlog::level::critical;
+    }
+    logger_->set_level(level_);
+}
+
+void Logger::set_logfile(const std::string& filename) {
+    if (!logfile_.empty()) {
+        // LOG_WARN("Already logging messages to {}", logfile_);
+        return;
+    }
+
+    logfile_ = filename;
+
+    try {
+        auto file_logger = spdlog::basic_logger_mt(FILE_LOGGER, filename);
+        file_logger->set_pattern(LOG_PATTERN);
+        file_logger->set_level(level_);
+    } catch (spdlog::spdlog_ex& e) {
+        // log message and exit if file logger cannot be created
+        LOG_FATAL(e.what());
+    }
+
+    // add sink to existing logger
+    // (https://github.com/gabime/spdlog/wiki/4.-Sinks)
+    auto file_sink = spdlog::get(FILE_LOGGER)->sinks().back();
+    logger_->sinks().push_back(file_sink);
+    logger_->flush_on(spdlog::level::info);
+}
+
+bool Logger::debug_enabled() {
+    return (level_ == spdlog::level::debug) || (level_ == spdlog::level::trace);
+}
+
+/* ********************************* */
+/*              GLOBAL               */
+/* ********************************* */
+
+Logger& global_logger() {
+    static Logger l;
+    return l;
+}
+
+/** Set log level for global logger. */
+void LOG_CONFIG(const std::string& level, const std::string& logfile) {
+    if (!level.empty()) {
+        global_logger().set_level(level);
+    }
+    if (!logfile.empty()) {
+        global_logger().set_logfile(logfile);
+    }
+}
+
+/** Set log level for global logger. */
+void LOG_SET_LEVEL(const std::string& level) {
+    global_logger().set_level(level);
+}
+
+/** Set log file for global logger. */
+void LOG_SET_FILE(const std::string& logfile) {
+    global_logger().set_logfile(logfile);
+}
+
+/** Check if global logger is logging debug messages. */
+bool LOG_DEBUG_ENABLED() {
+    return global_logger().debug_enabled();
+}
+
+/** Logs a trace message. */
+void LOG_TRACE(const std::string& msg) {
+    global_logger().trace(msg.c_str());
+}
+
+/** Logs a debug message. */
+void LOG_DEBUG(const std::string& msg) {
+    global_logger().debug(msg.c_str());
+}
+
+/** Logs an info message. */
+void LOG_INFO(const std::string& msg) {
+    global_logger().info(msg.c_str());
+}
+
+/** Logs a warning. */
+void LOG_WARN(const std::string& msg) {
+    global_logger().warn(msg.c_str());
+}
+
+/** Logs an error. */
+void LOG_ERROR(const std::string& msg) {
+    global_logger().error(msg.c_str());
+}
+
+/** Logs a critical error and exits with a non-zero status. */
+void LOG_FATAL(const std::string& msg) {
+    global_logger().critical(msg.c_str());
+    exit(1);
+}
+
+/** Convert TileDB timestamp (in ms) to human readable timestamp. */
+std::string asc_timestamp(uint64_t timestamp_ms) {
+    auto time_sec = static_cast<time_t>(timestamp_ms) / 1000;
+    std::string time_str = asctime(gmtime(&time_sec));
+    time_str.pop_back();  // remove newline
+    time_str += " UTC";
+    return time_str;
+}
+
+}  // namespace tiledbsc

--- a/libtiledbsc/src/logger.h
+++ b/libtiledbsc/src/logger.h
@@ -1,0 +1,249 @@
+/**
+ * @file   logger.h
+ *
+ * @section LICENSE
+ *
+ * The MIT License
+ *
+ * @copyright Copyright (c) 2017-2021 TileDB, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ *
+ * This file defines class Logger, which is implemented as a wrapper around
+ * `spdlog`. By policy `spdlog` must remain encapsulated as an implementation
+ * and not be exposed as a dependency of the TileDB library. Accordingly, this
+ * header should not be included as a header in any other header file. For
+ * inclusion in a header (notably for use within the definition of
+ * template-dependent functions), include the header `logger_public.h`.
+ *
+ * The reason for this restriction is a technical limitation in template
+ * instantiation. Part of the interface to `spdlog` consists of template
+ * functions with variadic template arguments. Instantiation of such function
+ * does not instantiate a variadic function (for exmaple `printf`) but rather a
+ * function with a fixed number of arguments that depend upon the argument list.
+ * Such variadic template argument lists cannot be forwarded across the
+ * boundaries of compilation units, so exposing variadic template arguments
+ * necessarily exposes the dependency upon `spdlog`. Thus this file `logger.h`,
+ * which does have such arguments, must remain entirely within the library, but
+ * `logger_public.h`, which does not have such arguments, may be exposed without
+ * creating an additional external dependency.
+ */
+
+#pragma once
+#ifndef TILEDB_LOGGER_H
+#define TILEDB_LOGGER_H
+
+#include <spdlog/spdlog.h>
+
+namespace tiledbsc {
+
+/** Definition of class Logger. */
+class Logger {
+   public:
+    /* ********************************* */
+    /*     CONSTRUCTORS & DESTRUCTORS    */
+    /* ********************************* */
+
+    /** Constructor. */
+    Logger();
+
+    /** Destructor. */
+    ~Logger();
+
+    /* ********************************* */
+    /*                API                */
+    /* ********************************* */
+
+    /**
+     * Log a trace statement with no message formatting.
+     *
+     * @param msg The string to log.
+     */
+    void trace(const char* msg);
+
+    /**
+     * A formatted trace statment.
+     *
+     * @param fmt A fmtlib format string, see http://fmtlib.net/latest/ for
+     *     details.
+     * @param arg positional argument to format.
+     * @param args optional additional positional arguments to format.
+     */
+    template <typename Arg1, typename... Args>
+    void trace(const char* fmt, const Arg1& arg1, const Args&... args) {
+        logger_->trace(fmt, arg1, args...);
+    }
+
+    /**
+     * Log a debug statement with no message formatting.
+     *
+     * @param msg The string to log.
+     */
+    void debug(const char* msg);
+
+    /**
+     * A formatted debug statment.
+     *
+     * @param fmt A fmtlib format string, see http://fmtlib.net/latest/ for
+     *     details.
+     * @param arg positional argument to format.
+     * @param args optional additional positional arguments to format.
+     */
+    template <typename Arg1, typename... Args>
+    void debug(const char* fmt, const Arg1& arg1, const Args&... args) {
+        logger_->debug(fmt, arg1, args...);
+    }
+
+    /**
+     * Log an info statement with no message formatting.
+     *
+     * @param msg The string to log.
+     */
+    void info(const char* msg);
+
+    /**
+     * A formatted info statment.
+     *
+     * @param fmt A fmtlib format string, see http://fmtlib.net/latest/ for
+     *     details.
+     * @param arg positional argument to format.
+     * @param args optional additional positional arguments to format.
+     */
+    template <typename Arg1, typename... Args>
+    void info(const char* fmt, const Arg1& arg1, const Args&... args) {
+        logger_->info(fmt, arg1, args...);
+    }
+
+    /**
+     * Log a warn statement with no message formatting.
+     *
+     * @param msg The string to log.
+     */
+    void warn(const char* msg);
+
+    /**
+     * A formatted warn statment.
+     *
+     * @param fmt A fmtlib format string, see http://fmtlib.net/latest/ for
+     *     details.
+     * @param arg positional argument to format.
+     * @param args optional additional positional arguments to format.
+     */
+    template <typename Arg1, typename... Args>
+    void warn(const char* fmt, const Arg1& arg1, const Args&... args) {
+        logger_->warn(fmt, arg1, args...);
+    }
+
+    /**
+     * Log an error with no message formatting.
+     *
+     * @param msg The string to log
+     * */
+    void error(const char* msg);
+
+    /** A formatted error statement.
+     *
+     * @param fmt A fmtlib format string, see http://fmtlib.net/latest/ for
+     * details.
+     * @param arg1 positional argument to format.
+     * @param args optional additional positional arguments to format.
+     */
+    template <typename Arg1, typename... Args>
+    void error(const char* fmt, const Arg1& arg1, const Args&... args) {
+        logger_->error(fmt, arg1, args...);
+    }
+
+    /**
+     * Log a critical statement with no message formatting.
+     *
+     * @param msg The string to log.
+     */
+    void critical(const char* msg);
+
+    /**
+     * A formatted critical statment.
+     *
+     * @param fmt A fmtlib format string, see http://fmtlib.net/latest/ for
+     *     details.
+     * @param arg positional argument to format.
+     * @param args optional additional positional arguments to format.
+     */
+    template <typename Arg1, typename... Args>
+    void critical(const char* fmt, const Arg1& arg1, const Args&... args) {
+        logger_->critical(fmt, arg1, args...);
+    }
+
+    /** Verbosity level. */
+    enum class Level : char {
+        FATAL,
+        ERR,
+        WARN,
+        INFO,
+        DBG,
+        TRACE,
+    };
+
+    /**
+     * Set the logger level.
+     *
+     * @param level log level string (FATAL|ERROR|WARN|INFO|DEBUG|TRACE)
+     */
+    void set_level(const std::string& level);
+
+    /**
+     * Set the logger output file.
+     *
+     * @param filename
+     */
+    void set_logfile(const std::string& filename);
+
+    /**
+     * Return true if debug messages are enabled.
+     */
+    bool debug_enabled();
+
+   private:
+    /* ********************************* */
+    /*         PRIVATE ATTRIBUTES        */
+    /* ********************************* */
+
+    /** The logger object. */
+    std::shared_ptr<spdlog::logger> logger_;
+    spdlog::level::level_enum level_;
+    std::string logfile_;
+};
+
+/* ********************************* */
+/*              GLOBAL               */
+/* ********************************* */
+
+/** Global logger function. */
+Logger& global_logger();
+
+}  // namespace tiledbsc
+
+/** Convert TileDB timestamp (in ms) to human readable timestamp. */
+std::string asc_timestamp(uint64_t timestamp_ms);
+
+// Also include the private logger functions here.
+#include "tiledbsc/logger_private.h"
+
+#endif  // TILEDB_LOGGER_H


### PR DESCRIPTION
Add `spdlog` support to the C++ API.

Example usage:
``` c++
#include <tiledbsc/logger_private.h>
...
    LOG_CONFIG("debug");
...
    LOG_INFO("walking soco URI = '{}'", uri);
...
```