### PR TITLE
Update to TileDB-Py 0.15.2

### DIFF
--- a/apis/python/setup.cfg
+++ b/apis/python/setup.cfg
@@ -32,7 +32,7 @@ zip_safe = False
 # The numpy pin is to avoid
 # "ImportError: Numba needs NumPy 1.21 or less"
 install_requires =
-    tiledb>=0.15.1
+    tiledb>=0.15.2
     scipy
     numpy<1.22
     pandas

--- a/apis/python/src/tiledbsc/annotation_matrix_group.py
+++ b/apis/python/src/tiledbsc/annotation_matrix_group.py
@@ -85,12 +85,9 @@ class AnnotationMatrixGroup(TileDBGroup):
         Member arrays are returned in sparse CSR format.
         """
 
-        grp = None
-        try:  # Not all groups have all four of obsm, obsp, varm, and varp.
-            grp = tiledb.Group(self.uri, mode="r")
-        except:
-            pass
-        if grp == None:
+        if (
+            not self.exists()
+        ):  # Not all groups have all four of obsm, obsp, varm, and varp.
             if self._verbose:
                 print(f"{self._indent}{self.uri} not found")
             return {}
@@ -99,29 +96,25 @@ class AnnotationMatrixGroup(TileDBGroup):
             s = util.get_start_stamp()
             print(f"{self._indent}START  read {self.uri}")
 
-        # TODO: fold this element-enumeration into the TileDB group class.  Maybe on the same PR
-        # where we support somagroup['name'] with overloading of the [] operator.
-        matrices_in_group = {}
-        for element in grp:
-            with tiledb.open(element.uri) as A:
-                with tiledb.open(element.uri) as A:
-                    if self._verbose:
-                        s2 = util.get_start_stamp()
-                        print(f"{self._indent}START  read {element.uri}")
+        with self._open() as G:
+            matrices_in_group = {}
+            for element in G:
+                if self._verbose:
+                    s2 = util.get_start_stamp()
+                    print(f"{self._indent}START  read {element.uri}")
 
+                with tiledb.open(element.uri) as A:
                     df = pd.DataFrame(A[:])
                     df.set_index(self.dim_name, inplace=True)
                     matrix_name = os.path.basename(element.uri)  # e.g. 'X_pca'
                     matrices_in_group[matrix_name] = df.to_numpy()
 
-                    if self._verbose:
-                        print(
-                            util.format_elapsed(
-                                s2, f"{self._indent}FINISH read {element.uri}"
-                            )
+                if self._verbose:
+                    print(
+                        util.format_elapsed(
+                            s2, f"{self._indent}FINISH read {element.uri}"
                         )
-
-        grp.close()
+                    )
 
         if self._verbose:
             print(util.format_elapsed(s, f"{self._indent}FINISH read {self.uri}"))
@@ -150,37 +143,25 @@ class AnnotationMatrixGroup(TileDBGroup):
         member exists.  Overloads the `[...]` operator.
         """
 
-        # TODO: If TileDB-Py were to support `name in G` the line-count could reduce here.
         with self._open("r") as G:
-            try:
-                obj = G[name]  # This returns a tiledb.object.Object.
-            except:
+            if not name in G:
                 return None
-
+            obj = G[name]  # This returns a tiledb.object.Object.
             if obj.type == tiledb.tiledb.Group:
                 raise Exception(
                     "Internal error: found group element where array element was expected."
                 )
-            elif obj.type == tiledb.libtiledb.Array:
-                return AnnotationMatrix(
-                    uri=obj.uri, name=name, dim_name=self.dim_name, parent=self
-                )
-            else:
+            if obj.type != tiledb.libtiledb.Array:
                 raise Exception(
                     f"Internal error: found group element neither subgroup nor array: type is {str(obj.type)}"
                 )
+            return AnnotationMatrix(
+                uri=obj.uri, name=name, dim_name=self.dim_name, parent=self
+            )
 
     def __contains__(self, name):
         """
         Implements the `in` operator, e.g. `"namegoeshere" in soma.obsm/soma.varm`.
         """
-        # TODO: this will get easier once TileDB.group.Group supports `name` in `__contains__`.
-        # See SC-18057 and https://github.com/single-cell-data/TileDB-SingleCell/issues/113.
         with self._open("r") as G:
-            answer = False
-            try:
-                # This returns a tiledb.object.Object.
-                G[name]
-                return True
-            except:
-                return False
+            return name in G

--- a/apis/python/src/tiledbsc/annotation_pairwise_matrix_group.py
+++ b/apis/python/src/tiledbsc/annotation_pairwise_matrix_group.py
@@ -201,13 +201,5 @@ class AnnotationPairwiseMatrixGroup(TileDBGroup):
         """
         Implements `"namegoeshere" in soma.obsp/soma.varp`.
         """
-        # TODO: this will get easier once TileDB.group.Group supports `name` in `__contains__`.
-        # See SC-18057 and https://github.com/single-cell-data/TileDB-SingleCell/issues/113.
         with self._open("r") as G:
-            answer = False
-            try:
-                # This returns a tiledb.object.Object.
-                G[name]
-                return True
-            except:
-                return False
+            return name in G

--- a/apis/python/src/tiledbsc/soma_collection.py
+++ b/apis/python/src/tiledbsc/soma_collection.py
@@ -74,15 +74,8 @@ class SOMACollection(TileDBGroup):
         """
         Implements `name in soco`
         """
-        # TODO: this will get easier once TileDB.group.Group supports `name` in `__contains__`.
-        # See SC-18057 and https://github.com/single-cell-data/TileDB-SingleCell/issues/113.
         with self._open("r") as G:
-            answer = False
-            try:
-                G[name]  # This returns a tiledb.object.Object.
-                return True
-            except:
-                return False
+            return name in G
 
     # At the tiledb-py API level, *all* groups are name-indexable.  But here at the tiledbsc-py
     # level, we implement name-indexing only for some groups:

--- a/apis/python/src/tiledbsc/uns_group.py
+++ b/apis/python/src/tiledbsc/uns_group.py
@@ -193,14 +193,5 @@ class UnsGroup(TileDBGroup):
         """
         Implements '"namegoeshere" in soma.uns'.
         """
-
-        # TODO: this will get easier once TileDB.group.Group supports `name` in `__contains__`.
-        # See SC-18057 and https://github.com/single-cell-data/TileDB-SingleCell/issues/113.
         with self._open("r") as G:
-            answer = False
-            try:
-                # This returns a tiledb.object.Object.
-                G[name]
-                return True
-            except:
-                return False
+            return name in G

--- a/apis/python/src/tiledbsc/uns_group.py
+++ b/apis/python/src/tiledbsc/uns_group.py
@@ -128,8 +128,6 @@ class UnsGroup(TileDBGroup):
             s = util.get_start_stamp()
             print(f"{self._indent}START  read {self.uri}")
 
-        # TODO: fold this element-enumeration into the TileDB group class.  Maybe on the same PR
-        # where we support somagroup['name'] with overloading of the [] operator.
         retval = {}
         for element in grp:
             name = os.path.basename(element.uri)  # TODO: update for tiledb cloud

--- a/apis/python/tests/test_soco_ops.py
+++ b/apis/python/tests/test_soco_ops.py
@@ -28,12 +28,8 @@ def test_import_anndata(tmp_path):
 
     soco = tiledbsc.SOMACollection(soco_dir)
 
-    # TODO: change this to with-open-as syntax once
-    # https://github.com/TileDB-Inc/TileDB-Py/pull/1124
-    # is in a TileDB-Py release which we articulate a dependency on.
-    G = tiledb.Group(soma1_dir)
-    assert G.meta[tiledbsc.util_tiledb.SOMA_OBJECT_TYPE_METADATA_KEY] == "SOMA"
-    G.close()
+    with tiledb.Group(soma1_dir) as G:
+        assert G.meta[tiledbsc.util_tiledb.SOMA_OBJECT_TYPE_METADATA_KEY] == "SOMA"
 
     soco._create()
     assert len(soco._get_member_names()) == 0

--- a/apis/python/tests/test_tiledbsc.py
+++ b/apis/python/tests/test_tiledbsc.py
@@ -51,12 +51,8 @@ def test_import_anndata(adata):
     #   raw/var
     #   raw/varm/PCs
 
-    # TODO: change this to with-open-as syntax once
-    # https://github.com/TileDB-Inc/TileDB-Py/pull/1124
-    # is in a TileDB-Py release which we articulate a dependency on.
-    G = tiledb.Group(output_path)
-    assert G.meta[tiledbsc.util_tiledb.SOMA_OBJECT_TYPE_METADATA_KEY] == "SOMA"
-    G.close()
+    with tiledb.Group(output_path) as G:
+        assert G.meta[tiledbsc.util_tiledb.SOMA_OBJECT_TYPE_METADATA_KEY] == "SOMA"
 
     # Check X/data (dense)
     with tiledb.open(os.path.join(output_path, "X", "data")) as A:


### PR DESCRIPTION
Include some features from [TileDB-Py 0.15.2](https://github.com/TileDB-Inc/TileDB-Py/releases/tag/0.15.2):

* `"name" in G`
* with-open-as for groups

More to come on #115 and #116.