### PR TITLE
Implement some convenience-accessors, imitating AnnData

### DIFF
--- a/apis/python/doc/README-ingestion.md
+++ b/apis/python/doc/README-ingestion.md
@@ -214,7 +214,6 @@ TTTAGCTGTACTCT           0       462.0            86                1           
 
 [80 rows x 7 columns]
 
->>> soma.var.df()
                vst.mean  vst.variance  vst.variance.expected  vst.variance.standardized  vst.variable
 var_id
 AKR1C3           0.2625      1.132753               0.553424                   2.021191             1

--- a/apis/python/doc/annotation_matrix_group.md
+++ b/apis/python/doc/annotation_matrix_group.md
@@ -10,7 +10,9 @@
 class AnnotationMatrixGroup(TileDBGroup)
 ```
 
-Nominally for soma obsm and varm.
+Nominally for soma obsm and varm. You can find element names using soma.obsm.keys(); you access
+elements using soma.obsm['X_pca'] etc., or soma.obsm.X_pca if you prefer.  (The latter syntax is
+possible when the element name doesn't have dashes, dots, etc. in it.)
 
 <a id="tiledbsc.annotation_matrix_group.AnnotationMatrixGroup.__init__"></a>
 
@@ -42,6 +44,17 @@ def __iter__() -> List[AnnotationMatrix]
 ```
 
 Implements `for matrix in soma.obsm: ...` and `for matrix in soma.varm: ...`
+
+<a id="tiledbsc.annotation_matrix_group.AnnotationMatrixGroup.__getattr__"></a>
+
+#### \_\_getattr\_\_
+
+```python
+def __getattr__(name)
+```
+
+This is called on `soma.obsm.name` when `name` is not already an attribute.
+This way you can do `soma.obsm.X_tsne` as an alias for `soma.obsm['X_tsne']`.
 
 <a id="tiledbsc.annotation_matrix_group.AnnotationMatrixGroup.from_matrices_and_dim_values"></a>
 

--- a/apis/python/doc/annotation_pairwise_matrix_group.md
+++ b/apis/python/doc/annotation_pairwise_matrix_group.md
@@ -10,7 +10,9 @@
 class AnnotationPairwiseMatrixGroup(TileDBGroup)
 ```
 
-Nominally for soma obsp and varp.
+Nominally for soma obsp and varp. You can find element names using soma.obsp.keys(); you access
+elements using soma.obsp['distances'] etc., or soma.obsp.distances if you prefer.  (The latter
+syntax is possible when the element name doesn't have dashes, dots, etc. in it.)
 
 <a id="tiledbsc.annotation_pairwise_matrix_group.AnnotationPairwiseMatrixGroup.__init__"></a>
 
@@ -38,6 +40,17 @@ def keys()
 
 For obsp and varp, `.keys()` is a keystroke-saver for the more general group-member
 accessor `._get_member_names()`.
+
+<a id="tiledbsc.annotation_pairwise_matrix_group.AnnotationPairwiseMatrixGroup.__getattr__"></a>
+
+#### \_\_getattr\_\_
+
+```python
+def __getattr__(name)
+```
+
+This is called on `soma.obsp.name` when `name` is not already an attribute.
+This way you can do `soma.obsp.distances` as an alias for `soma.obsp['distances']`.
 
 <a id="tiledbsc.annotation_pairwise_matrix_group.AnnotationPairwiseMatrixGroup.__iter__"></a>
 
@@ -71,10 +84,11 @@ arrays under that group.
 #### to\_dict\_of\_csr
 
 ```python
-def to_dict_of_csr() -> Dict[str, scipy.sparse.csr_matrix]
+def to_dict_of_csr(obs_df_index,
+                   var_df_index) -> Dict[str, scipy.sparse.csr_matrix]
 ```
 
-Reads the `obsm` or `varm` group-member arrays into a dict from name to member array.
+Reads the `obsp` or `varp` group-member arrays into a dict from name to member array.
 Member arrays are returned in sparse CSR format.
 
 <a id="tiledbsc.annotation_pairwise_matrix_group.AnnotationPairwiseMatrixGroup.__getitem__"></a>

--- a/apis/python/doc/assay_matrix_group.md
+++ b/apis/python/doc/assay_matrix_group.md
@@ -10,7 +10,9 @@
 class AssayMatrixGroup(TileDBGroup)
 ```
 
-Nominally for `X`, `raw/X`, `obsp` elements, and `varp` elements.
+Nominally for `X` and `raw/X` elements.  You can find element names using soma.X.keys(); you
+access elements using soma.X['data'] etc., or soma.X.data if you prefer.  (The latter syntax is
+possible when the element name doesn't have dashes, dots, etc. in it.)
 
 <a id="tiledbsc.assay_matrix_group.AssayMatrixGroup.__init__"></a>
 
@@ -30,6 +32,59 @@ See the `TileDBObject` constructor.
 
 See `AssayMatrix` for the rationale behind retaining references to the `row_dataframe` and
 `col_dataframe` objects.
+
+<a id="tiledbsc.assay_matrix_group.AssayMatrixGroup.keys"></a>
+
+#### keys
+
+```python
+def keys()
+```
+
+For `obsm` and `varm`, `.keys()` is a keystroke-saver for the more general group-member
+accessor `._get_member_names()`.
+
+<a id="tiledbsc.assay_matrix_group.AssayMatrixGroup.__getattr__"></a>
+
+#### \_\_getattr\_\_
+
+```python
+def __getattr__(name)
+```
+
+This is called on `soma.X.name` when `name` is not already an attribute.
+This way you can do `soma.X.data` as an alias for `soma.X['data']`.
+
+<a id="tiledbsc.assay_matrix_group.AssayMatrixGroup.__iter__"></a>
+
+#### \_\_iter\_\_
+
+```python
+def __iter__() -> List[AssayMatrix]
+```
+
+Implements `for matrix in soma.obsm: ...` and `for matrix in soma.varm: ...`
+
+<a id="tiledbsc.assay_matrix_group.AssayMatrixGroup.__getitem__"></a>
+
+#### \_\_getitem\_\_
+
+```python
+def __getitem__(name)
+```
+
+Returns an `AnnotationMatrix` element at the given name within the group, or None if no such
+member exists.  Overloads the `[...]` operator.
+
+<a id="tiledbsc.assay_matrix_group.AssayMatrixGroup.__contains__"></a>
+
+#### \_\_contains\_\_
+
+```python
+def __contains__(name)
+```
+
+Implements the `in` operator, e.g. `"data" in soma.X`.
 
 <a id="tiledbsc.assay_matrix_group.AssayMatrixGroup.from_matrix_and_dim_values"></a>
 

--- a/apis/python/doc/soma.md
+++ b/apis/python/doc/soma.md
@@ -18,8 +18,12 @@ which includes:
 * `obs` (`AnnotationDataframe`): 1D labeled array with column labels for `X`
 * `var` (`AnnotationDataframe`): 1D labeled array with row labels for `X`
 
-See also desc-ann.py in this directory for helpful information to
-reveal the diversity/variety of HDF5 files we process.
+Convenience accessors include:
+
+* `soma.obs_keys()` for `soma.obs_names` for `soma.obs.ids()`
+* `soma.var_keys()` for `soma.var_names` for `soma.var.ids()`
+* `soma.n_obs` for `soma.obs.shape()[0]`
+* `soma.n_var` for `soma.var.shape()[0]`
 
 <a id="tiledbsc.soma.SOMA.__init__"></a>
 
@@ -51,4 +55,35 @@ def __str__()
 ```
 
 Implements `print(soma)`.
+
+<a id="tiledbsc.soma.SOMA.__getattr__"></a>
+
+#### \_\_getattr\_\_
+
+```python
+def __getattr__(name)
+```
+
+This is called on `soma.name` when `name` is not already an attribute.
+This is used for `soma.n_obs`, etc.
+
+<a id="tiledbsc.soma.SOMA.obs_keys"></a>
+
+#### obs\_keys
+
+```python
+def obs_keys()
+```
+
+An alias for `soma.obs.ids()`.
+
+<a id="tiledbsc.soma.SOMA.var_keys"></a>
+
+#### var\_keys
+
+```python
+def var_keys()
+```
+
+An alias for `soma.var.ids()`.
 

--- a/apis/python/doc/tiledb_array.md
+++ b/apis/python/doc/tiledb_array.md
@@ -19,7 +19,7 @@ requested.
 #### \_\_init\_\_
 
 ```python
-def __init__(uri: str, name: str, parent: Optional[TileDBGroup] = None)
+def __init__(uri: str, name: str, parent=None)
 ```
 
 See the TileDBObject constructor.
@@ -96,14 +96,13 @@ def has_attr_name(attr_name: str) -> bool
 
 Returns true if the array has the specified attribute name, false otherwise.
 
-<a id="tiledbsc.tiledb_array.TileDBArray.set_soma_object_type_metadata"></a>
+<a id="tiledbsc.tiledb_array.TileDBArray.show_metadata"></a>
 
-#### set\_soma\_object\_type\_metadata
+#### show\_metadata
 
 ```python
-def set_soma_object_type_metadata() -> None
+def show_metadata(recursively=True, indent="")
 ```
 
-This helps nested-structured traversals (especially those that start at the SOMACollection
-level) confidently navigate with a minimum of introspection on group contents.
+Shows metadata for the array.
 

--- a/apis/python/doc/tiledb_group.md
+++ b/apis/python/doc/tiledb_group.md
@@ -39,3 +39,13 @@ Tells whether or not there is storage for the group. This might be in case a SOM
 object has not yet been populated, e.g. before calling `from_anndata` -- or, if the
 SOMA has been populated but doesn't have this member (e.g. not all SOMAs have a `varp`).
 
+<a id="tiledbsc.tiledb_group.TileDBGroup.show_metadata"></a>
+
+#### show\_metadata
+
+```python
+def show_metadata(recursively=True, indent="")
+```
+
+Shows metadata for the group, recursively by default.
+

--- a/apis/python/doc/tiledb_object.md
+++ b/apis/python/doc/tiledb_object.md
@@ -31,3 +31,54 @@ verbose, and ctx for the top-level object; omit them and specify parent for non-
 objects. Note that the parent reference is solely for propagating options, ctx, display
 depth, etc.
 
+<a id="tiledbsc.tiledb_object.TileDBObject.metadata"></a>
+
+#### metadata
+
+```python
+def metadata() -> Dict
+```
+
+Returns metadata from the group/array as a dict.
+
+<a id="tiledbsc.tiledb_object.TileDBObject.has_metadata"></a>
+
+#### has\_metadata
+
+```python
+def has_metadata(key)
+```
+
+Returns whether metadata is associated with the group/array.
+
+<a id="tiledbsc.tiledb_object.TileDBObject.metadata_keys"></a>
+
+#### metadata\_keys
+
+```python
+def metadata_keys() -> List[str]
+```
+
+Returns metadata keys associated with the group/array.
+
+<a id="tiledbsc.tiledb_object.TileDBObject.get_metadata"></a>
+
+#### get\_metadata
+
+```python
+def get_metadata(key)
+```
+
+Returns metadata associated with the group/array.
+Raises `KeyError` if there is no such key in the metadata.
+
+<a id="tiledbsc.tiledb_object.TileDBObject.set_metadata"></a>
+
+#### set\_metadata
+
+```python
+def set_metadata(key: str, value) -> None
+```
+
+Returns metadata associated with the group/array.
+

--- a/apis/python/doc/uns_group.md
+++ b/apis/python/doc/uns_group.md
@@ -33,6 +33,47 @@ def keys()
 For uns, `.keys()` is a keystroke-saver for the more general group-member
 accessor `._get_member_names()`.
 
+<a id="tiledbsc.uns_group.UnsGroup.__getitem__"></a>
+
+#### \_\_getitem\_\_
+
+```python
+def __getitem__(name)
+```
+
+Returns an `UnsArray` or `UnsGroup` element at the given name within the group, or None if
+no such member exists.  Overloads the [...] operator.
+
+<a id="tiledbsc.uns_group.UnsGroup.__contains__"></a>
+
+#### \_\_contains\_\_
+
+```python
+def __contains__(name)
+```
+
+Implements '"namegoeshere" in soma.uns'.
+
+<a id="tiledbsc.uns_group.UnsGroup.__iter__"></a>
+
+#### \_\_iter\_\_
+
+```python
+def __iter__() -> List
+```
+
+Implements `for element in soma.uns: ...`
+
+<a id="tiledbsc.uns_group.UnsGroup.show"></a>
+
+#### show
+
+```python
+def show(display_name="uns")
+```
+
+Recursively displays the uns data.
+
 <a id="tiledbsc.uns_group.UnsGroup.from_anndata_uns"></a>
 
 #### from\_anndata\_uns
@@ -56,25 +97,4 @@ def to_dict_of_matrices() -> Dict
 ```
 
 Reads the recursive group/array uns data from TileDB storage and returns them as a recursive dict of matrices.
-
-<a id="tiledbsc.uns_group.UnsGroup.__getitem__"></a>
-
-#### \_\_getitem\_\_
-
-```python
-def __getitem__(name)
-```
-
-Returns an `UnsArray` or `UnsGroup` element at the given name within the group, or None if
-no such member exists.  Overloads the [...] operator.
-
-<a id="tiledbsc.uns_group.UnsGroup.__contains__"></a>
-
-#### \_\_contains\_\_
-
-```python
-def __contains__(name)
-```
-
-Implements '"namegoeshere" in soma.uns'.
 

--- a/apis/python/src/tiledbsc/annotation_matrix_group.py
+++ b/apis/python/src/tiledbsc/annotation_matrix_group.py
@@ -54,6 +54,19 @@ class AnnotationMatrixGroup(TileDBGroup):
         return iter(retval)
 
     # ----------------------------------------------------------------
+    def __getattr__(self, name):
+        """
+        This is called on `soma.obsm.name` when `name` is not already an attribute.
+        This way you can do `soma.obsm.X_tsne` as an alias for `soma.obsm['X_tsne']`.
+        """
+        with self._open() as G:
+            if not name in G:
+                raise AttributeError(
+                    f"'{self.__class__.__name__}' object has no attribute '{name}'"
+                )
+        return self[name]
+
+    # ----------------------------------------------------------------
     def from_matrices_and_dim_values(self, annotation_matrices, dim_values):
         """
         Populates the `obsm` or `varm` subgroup for a SOMA object, then writes all the components

--- a/apis/python/src/tiledbsc/annotation_matrix_group.py
+++ b/apis/python/src/tiledbsc/annotation_matrix_group.py
@@ -13,7 +13,9 @@ import os
 
 class AnnotationMatrixGroup(TileDBGroup):
     """
-    Nominally for soma obsm and varm.
+    Nominally for soma obsm and varm. You can find element names using soma.obsm.keys(); you access
+    elements using soma.obsm['X_pca'] etc., or soma.obsm.X_pca if you prefer.  (The latter syntax is
+    possible when the element name doesn't have dashes, dots, etc. in it.)
     """
 
     dim_name: str

--- a/apis/python/src/tiledbsc/annotation_pairwise_matrix_group.py
+++ b/apis/python/src/tiledbsc/annotation_pairwise_matrix_group.py
@@ -55,6 +55,19 @@ class AnnotationPairwiseMatrixGroup(TileDBGroup):
         return self._get_member_names()
 
     # ----------------------------------------------------------------
+    def __getattr__(self, name):
+        """
+        This is called on `soma.obsp.name` when `name` is not already an attribute.
+        This way you can do `soma.obsp.distances` as an alias for `soma.obsp['distances']`.
+        """
+        with self._open() as G:
+            if not name in G:
+                raise AttributeError(
+                    f"'{self.__class__.__name__}' object has no attribute '{name}'"
+                )
+        return self[name]
+
+    # ----------------------------------------------------------------
     def __iter__(self) -> List[AssayMatrix]:
         """
         Implements `for matrix in soma.obsp: ...` and `for matrix in soma.varp: ...`

--- a/apis/python/src/tiledbsc/annotation_pairwise_matrix_group.py
+++ b/apis/python/src/tiledbsc/annotation_pairwise_matrix_group.py
@@ -14,7 +14,9 @@ import os
 
 class AnnotationPairwiseMatrixGroup(TileDBGroup):
     """
-    Nominally for soma obsp and varp.
+    Nominally for soma obsp and varp. You can find element names using soma.obsp.keys(); you access
+    elements using soma.obsp['distances'] etc., or soma.obsp.distances if you prefer.  (The latter
+    syntax is possible when the element name doesn't have dashes, dots, etc. in it.)
     """
 
     row_dim_name: str
@@ -122,7 +124,7 @@ class AnnotationPairwiseMatrixGroup(TileDBGroup):
         self, obs_df_index, var_df_index
     ) -> Dict[str, scipy.sparse.csr_matrix]:
         """
-        Reads the `obsm` or `varm` group-member arrays into a dict from name to member array.
+        Reads the `obsp` or `varp` group-member arrays into a dict from name to member array.
         Member arrays are returned in sparse CSR format.
         """
 

--- a/apis/python/src/tiledbsc/assay_matrix_group.py
+++ b/apis/python/src/tiledbsc/assay_matrix_group.py
@@ -11,7 +11,9 @@ import os
 
 class AssayMatrixGroup(TileDBGroup):
     """
-    Nominally for `X`, `raw/X`, `obsp` elements, and `varp` elements.
+    Nominally for `X` and `raw/X` elements.  You can find element names using soma.X.keys(); you
+    access elements using soma.X['data'] etc., or soma.X.data if you prefer.  (The latter syntax is
+    possible when the element name doesn't have dashes, dots, etc. in it.)
     """
 
     row_dim_name: str

--- a/apis/python/src/tiledbsc/assay_matrix_group.py
+++ b/apis/python/src/tiledbsc/assay_matrix_group.py
@@ -52,6 +52,19 @@ class AssayMatrixGroup(TileDBGroup):
         return self._get_member_names()
 
     # ----------------------------------------------------------------
+    def __getattr__(self, name):
+        """
+        This is called on `soma.X.name` when `name` is not already an attribute.
+        This way you can do `soma.X.data` as an alias for `soma.X['data']`.
+        """
+        with self._open() as G:
+            if not name in G:
+                raise AttributeError(
+                    f"'{self.__class__.__name__}' object has no attribute '{name}'"
+                )
+        return self[name]
+
+    # ----------------------------------------------------------------
     def __iter__(self) -> List[AssayMatrix]:
         """
         Implements `for matrix in soma.obsm: ...` and `for matrix in soma.varm: ...`

--- a/apis/python/src/tiledbsc/soma.py
+++ b/apis/python/src/tiledbsc/soma.py
@@ -136,3 +136,37 @@ class SOMA(TileDBGroup):
         Implements `print(soma)`.
         """
         return f"name={self.name},uri={self.uri}"
+
+    # ----------------------------------------------------------------
+    def __getattr__(self, name):
+        """
+        This is called on `soma.name` when `name` is not already an attribute.
+        This is used for `soma.n_obs`, etc.
+        """
+        if name == "n_obs":
+            return self.obs.shape()[0]
+        if name == "n_var":
+            return self.var.shape()[0]
+
+        if name == "obs_names":
+            return soma.obs.ids()
+        if name == "var_names":
+            return soma.var.ids()
+
+        raise AttributeError(
+            f"'{self.__class__.__name__}' object has no attribute '{name}'"
+        )
+
+    # ----------------------------------------------------------------
+    def obs_keys(self):
+        """
+        An alias for `soma.obs.ids()`.
+        """
+        return self.obs.ids()
+
+    # ----------------------------------------------------------------
+    def var_keys(self):
+        """
+        An alias for `soma.var.ids()`.
+        """
+        return self.var.ids()

--- a/apis/python/src/tiledbsc/soma.py
+++ b/apis/python/src/tiledbsc/soma.py
@@ -31,8 +31,12 @@ class SOMA(TileDBGroup):
     * `obs` (`AnnotationDataframe`): 1D labeled array with column labels for `X`
     * `var` (`AnnotationDataframe`): 1D labeled array with row labels for `X`
 
-    See also desc-ann.py in this directory for helpful information to
-    reveal the diversity/variety of HDF5 files we process.
+    Convenience accessors include:
+
+    * `soma.obs_keys()` for `soma.obs_names` for `soma.obs.ids()`
+    * `soma.var_keys()` for `soma.var_names` for `soma.var.ids()`
+    * `soma.n_obs` for `soma.obs.shape()[0]`
+    * `soma.n_var` for `soma.var.shape()[0]`
     """
 
     X: AssayMatrixGroup
@@ -149,9 +153,9 @@ class SOMA(TileDBGroup):
             return self.var.shape()[0]
 
         if name == "obs_names":
-            return soma.obs.ids()
+            return self.obs.ids()
         if name == "var_names":
-            return soma.var.ids()
+            return self.var.ids()
 
         raise AttributeError(
             f"'{self.__class__.__name__}' object has no attribute '{name}'"

--- a/apis/python/tests/test_tiledbsc.py
+++ b/apis/python/tests/test_tiledbsc.py
@@ -63,6 +63,8 @@ def test_import_anndata(adata):
         assert (
             A.meta[tiledbsc.util_tiledb.SOMA_OBJECT_TYPE_METADATA_KEY] == "AssayMatrix"
         )
+    # Convenience accessors
+    assert soma.X["data"].shape() == soma.X.data.shape()
 
     # Check X/raw (sparse)
     with tiledb.open(os.path.join(output_path, "raw", "X", "data")) as A:
@@ -83,6 +85,10 @@ def test_import_anndata(adata):
             == "AnnotationDataFrame"
         )
     assert sorted(soma.obs.ids()) == sorted(list(orig.obs_names))
+    # Convenience accessors
+    assert soma.obs_keys() == soma.obs_names
+    assert soma.obs_names == soma.obs.ids()
+    assert soma.n_obs == len(soma.obs.ids())
 
     # Check var
     with tiledb.open(os.path.join(output_path, "var")) as A:
@@ -93,6 +99,10 @@ def test_import_anndata(adata):
             == "AnnotationDataFrame"
         )
     assert sorted(soma.var.ids()) == sorted(list(orig.var_names))
+    # Convenience accessors
+    assert soma.var_keys() == soma.var_names
+    assert soma.var_names == soma.var.ids()
+    assert soma.n_var == len(soma.var.ids())
 
     # Check some annotation matrices
     # Note: pbmc3k_processed doesn't have varp.
@@ -106,6 +116,9 @@ def test_import_anndata(adata):
                 A.meta[tiledbsc.util_tiledb.SOMA_OBJECT_TYPE_METADATA_KEY]
                 == "AnnotationMatrix"
             )
+    # Convenience accessors: soma.obsm.X_pca <-> soma.obsm['X_pca']
+    for key in soma.obsm.keys():
+        assert getattr(soma.obsm, key).shape() == soma.obsm[key].shape()
 
     assert sorted(soma.varm.keys()) == sorted(orig.varm.keys())
     for key in orig.varm_keys():
@@ -117,6 +130,9 @@ def test_import_anndata(adata):
                 A.meta[tiledbsc.util_tiledb.SOMA_OBJECT_TYPE_METADATA_KEY]
                 == "AnnotationMatrix"
             )
+    # Convenience accessors:
+    for key in soma.varm.keys():
+        assert getattr(soma.varm, key).shape() == soma.varm[key].shape()
 
     assert sorted(soma.obsp.keys()) == sorted(orig.obsp.keys())
     for key in list(orig.obsp.keys()):
@@ -135,6 +151,9 @@ def test_import_anndata(adata):
                 A.meta[tiledbsc.util_tiledb.SOMA_OBJECT_TYPE_METADATA_KEY]
                 == "AssayMatrix"
             )
+    # Convenience accessors:
+    for key in soma.obsp.keys():
+        assert getattr(soma.obsp, key).shape() == soma.obsp[key].shape()
 
     tempdir.cleanup()
 


### PR DESCRIPTION
These include:

* `soma.obs_keys()` for `soma.obs_names` for `soma.obs.ids()`
* `soma.var_keys()` for `soma.var_names` for `soma.var.ids()`
* `soma.n_obs` for `soma.obs.shape()[0]`
* `soma.n_var` for `soma.var.shape()[0]`

Also:

* `soma.X.data` for `soma.X['data']`
* `soma.obsm.X_pca` for `soma.obsm['X_pca']`
* `soma.obsp.distances` for `soma.obsp['distances']`

See also #125