### PR TITLE
Allow S3 ingest

### DIFF
--- a/apis/python/src/tiledbsc/util.py
+++ b/apis/python/src/tiledbsc/util.py
@@ -10,6 +10,20 @@ import time
 from typing import Optional, List
 
 # ----------------------------------------------------------------
+def is_local_path(path: str) -> bool:
+    """
+
+    Returns information about start time of an event. Nominally float seconds since the epoch,
+    but articulated here as being compatible with the format_elapsed function.
+    """
+    if path.startswith("file://"):
+        return True
+    if "://" in path:
+        return False
+    return True
+
+
+# ----------------------------------------------------------------
 def get_start_stamp():
     """
     Returns information about start time of an event. Nominally float seconds since the epoch,

--- a/apis/python/tools/ingestor
+++ b/apis/python/tools/ingestor
@@ -17,6 +17,8 @@
 
 import tiledbsc
 import tiledbsc.io
+import tiledbsc.util
+import tiledb
 import sys, os, shutil
 import argparse
 
@@ -130,7 +132,8 @@ select `relative=True`. (This is the default.)
 
 def ingest_one(input_path: str, output_path: str, ifexists: str, soma_options: tiledbsc.SOMAOptions, verbose: bool):
     # Check that the input exists.
-    if not os.path.exists(input_path):
+    vfs = tiledb.VFS()
+    if not vfs.is_file(input_path):
         # Print this neatly and exit neatly, to avoid a multi-line stack trace otherwise.
         print(f"Input path not found: {input_path}", file=sys.stderr)
         sys.exit(1)
@@ -140,8 +143,9 @@ def ingest_one(input_path: str, output_path: str, ifexists: str, soma_options: t
     # use tiledb.vfs to remove any priors, and/or make use of a tiledb `overwrite` flag.
     parent = os.path.dirname(output_path.rstrip("/"))
     if parent != "":
-        if not os.path.exists(parent):
-            os.mkdir(parent)
+        if tiledbsc.util.is_local_path(parent):
+            if not os.path.exists(parent):
+                os.mkdir(parent)
 
     soma = tiledbsc.SOMA(uri=output_path, soma_options=soma_options)
 

--- a/apis/python/tools/outgestor
+++ b/apis/python/tools/outgestor
@@ -13,9 +13,10 @@
 # URIs will be supported.
 # ================================================================
 
-import tiledb
 import tiledbsc
 import tiledbsc.io
+import tiledbsc.util
+import tiledb
 
 import anndata as ad
 
@@ -65,15 +66,17 @@ def main():
         parser.print_help(file=sys.stderr)
         sys.exit(1)
 
-    if not os.path.exists(input_path):
+    vfs = tiledb.VFS()
+    if not vfs.is_dir(input_path):
         # Print this neatly and exit neatly, to avoid a multi-line stack trace otherwise.
         print(f"Input path not found: {input_path}", file=sys.stderr)
         sys.exit(1)
 
     # This is for local-disk use only -- for S3-backed tiledb://... URIs we should
     # use tiledb.vfs to remove any priors, and/or make use of a tiledb `overwrite` flag.
-    if not os.path.exists(outdir):
-        os.mkdir(outdir)
+    if tiledbsc.util.is_local_path(outdir):
+        if not os.path.exists(outdir):
+            os.mkdir(outdir)
 
     verbose = not args.quiet
     soma = tiledbsc.SOMA(input_path, verbose=verbose)


### PR DESCRIPTION
Just one spot in `tools/ingestor`. All other callsites within the package seem to be well-handled already via `tiledb.methodnamegoeshere(..., ctx=self._ctx)`.

```
$ ingestor anndata/pbmc-small.h5ad s3://tiledb-johnkerl/scratch/pbmc-small-s3-upload
START  SOMA.from_h5ad anndata/pbmc-small.h5ad -> s3://tiledb-johnkerl/scratch/pbmc-small-s3-upload
START  READING anndata/pbmc-small.h5ad
FINISH READING anndata/pbmc-small.h5ad TIME 0.048 seconds
START  DECATEGORICALIZING
FINISH DECATEGORICALIZING TIME 0.005 seconds
START  WRITING s3://tiledb-johnkerl/scratch/pbmc-small-s3-upload
Creating TileDB group s3://tiledb-johnkerl/scratch/pbmc-small-s3-upload
  START  WRITING s3://tiledb-johnkerl/scratch/pbmc-small-s3-upload/obs
  FINISH WRITING s3://tiledb-johnkerl/scratch/pbmc-small-s3-upload/obs TIME 3.225 seconds
  START  WRITING s3://tiledb-johnkerl/scratch/pbmc-small-s3-upload/var
  FINISH WRITING s3://tiledb-johnkerl/scratch/pbmc-small-s3-upload/var TIME 3.882 seconds
  Creating TileDB group s3://tiledb-johnkerl/scratch/pbmc-small-s3-upload/X
    START  WRITING s3://tiledb-johnkerl/scratch/pbmc-small-s3-upload/X/data
    START  __ingest_coo_data_string_dims_dense_rows_chunked
    START  chunk rows 0..499999 of 80 (624998.750%), obs_ids AAATTCGAATCACG..TTTAGCTGTACTCT, nnz=1600
    FINISH chunk in 1.097 seconds, 624998.750% done, ETA -2.01 seconds
    FINISH __ingest_coo_data_string_dims_dense_rows_chunked TIME 1.209 seconds
    FINISH WRITING s3://tiledb-johnkerl/scratch/pbmc-small-s3-upload/X/data TIME 2.239 seconds
...
  START  WRITING s3://tiledb-johnkerl/scratch/pbmc-small-s3-upload/uns
  Creating TileDB group s3://tiledb-johnkerl/scratch/pbmc-small-s3-upload/uns
    START  WRITING s3://tiledb-johnkerl/scratch/pbmc-small-s3-upload/uns/neighbors
    Creating TileDB group s3://tiledb-johnkerl/scratch/pbmc-small-s3-upload/uns/neighbors
      START  WRITING s3://tiledb-johnkerl/scratch/pbmc-small-s3-upload/uns/neighbors/params
      Creating TileDB group s3://tiledb-johnkerl/scratch/pbmc-small-s3-upload/uns/neighbors/params
        START  WRITING FROM NUMPY.NDARRAY s3://tiledb-johnkerl/scratch/pbmc-small-s3-upload/uns/neighbors/params/method
        FINISH WRITING FROM NUMPY.NDARRAY s3://tiledb-johnkerl/scratch/pbmc-small-s3-upload/uns/neighbors/params/method TIME 1.810 seconds
      FINISH WRITING s3://tiledb-johnkerl/scratch/pbmc-small-s3-upload/uns/neighbors/params TIME 3.066 seconds
    FINISH WRITING s3://tiledb-johnkerl/scratch/pbmc-small-s3-upload/uns/neighbors TIME 4.165 seconds
  FINISH WRITING s3://tiledb-johnkerl/scratch/pbmc-small-s3-upload/uns TIME 5.227 seconds
FINISH WRITING s3://tiledb-johnkerl/scratch/pbmc-small-s3-upload TIME 49.829 seconds
FINISH SOMA.from_h5ad anndata/pbmc-small.h5ad -> s3://tiledb-johnkerl/scratch/pbmc-small-s3-upload TIME 49.881 seconds
```

```
$ peek-soma s3://tiledb-johnkerl/scratch/pbmc-small-s3-upload
soma.>>> soma.obs.df()
                orig.ident  nCount_RNA  nFeature_RNA  RNA_snn_res.0.8  letter.idents groups  RNA_snn_res.1
obs_id
AAATTCGAATCACG           0       327.0            62                1              1     g2              1
AAGCAAGAGCTTAG           0       126.0            48                0              0     g1              0
AAGCGACTTTGACG           0       443.0            77                1              1     g1              1
AATGCGTGGACGGA           0       389.0            73                1              1     g1              1
AATGTTGACAGTCA           0       100.0            41                0              0     g1              0
...                    ...         ...           ...              ...            ...    ...            ...
TTACGTACGTTCAG           0       228.0            39                0              0     g1              0
TTGAGGACTACGCA           0       787.0            88                0              0     g1              2
TTGCATTGAGCTAC           0       104.0            40                0              0     g2              2
TTGGTACTGAATCC           0       135.0            45                0              0     g1              2
TTTAGCTGTACTCT           0       462.0            86                1              1     g1              1

[80 rows x 7 columns]
>>> soma.var.df()
               vst.mean  vst.variance  vst.variance.expected  vst.variance.standardized  vst.variable
var_id
AKR1C3           0.2625      1.132753               0.553424                   2.021191             1
CA2              0.4500      3.263291               1.685451                   1.765922             1
CD1C             0.1750      0.576582               0.271217                   2.052014             1
GNLY             2.4000     43.762025              24.078566                   1.817468             1
HLA-DPB1         7.6500    309.800000             199.154430                   1.555577             1
HLA-DQA1         1.9875     32.164399              19.810998                   1.623563             1
IGLL5            0.4875      9.316297               1.934066                   2.146804             1
MYL9             0.2875      1.321361               0.614125                   1.938228             1
PARVB            0.2375      0.740348               0.457305                   1.618937             1
PF4              2.1500     65.243038              21.482754                   1.939028             1
PGRMC1           0.2750      0.961392               0.584285                   1.645418             1
PPBP             5.3250    231.817089              93.148559                   2.488681             1
RP11-290F20.3    0.3250      1.082911               0.698644                   1.550018             1
RUFY1            0.3500      1.420253               0.844517                   1.572899             1
S100A8           2.9750     53.012025              32.261112                   1.643218             1
S100A9           6.8375    240.644146             156.219313                   1.540425             1
SDPR             1.1125     15.746677               8.835280                   1.680686             1
TREML1           0.3375      1.365665               0.761869                   1.792519             1
TUBB1            0.8875     16.202373               6.352400                   1.634371             1
VDAC3            1.1250     30.971519               8.986513                   2.137607             1
>>>
```

```
$ outgestor s3://tiledb-johnkerl/scratch/pbmc-small-s3-upload s3-readback.h5ad
START  SOMA.to_h5ad s3://tiledb-johnkerl/scratch/pbmc-small-s3-upload -> s3-readback.h5ad
START  SOMA.to_anndata s3://tiledb-johnkerl/scratch/pbmc-small-s3-upload
  START  read s3://tiledb-johnkerl/scratch/pbmc-small-s3-upload/obs
  FINISH read s3://tiledb-johnkerl/scratch/pbmc-small-s3-upload/obs TIME 0.773 seconds
  START  read s3://tiledb-johnkerl/scratch/pbmc-small-s3-upload/var
  FINISH read s3://tiledb-johnkerl/scratch/pbmc-small-s3-upload/var TIME 0.539 seconds
...
FINISH SOMA.to_anndata s3://tiledb-johnkerl/scratch/pbmc-small-s3-upload TIME 7.774 seconds
START  write s3-readback.h5ad
FINISH write s3-readback.h5ad TIME 0.044 seconds
FINISH SOMA.to_h5ad s3://tiledb-johnkerl/scratch/pbmc-small-s3-upload -> s3-readback.h5ad TIME 7.819 seconds
```

```
$ peek-ann s3-readback.h5adan>>> ann.obs
                orig.ident  nCount_RNA  nFeature_RNA  RNA_snn_res.0.8  letter.idents groups  RNA_snn_res.1
obs_id
AAATTCGAATCACG           0       327.0            62                1              1     g2              1
AAGCAAGAGCTTAG           0       126.0            48                0              0     g1              0
AAGCGACTTTGACG           0       443.0            77                1              1     g1              1
AATGCGTGGACGGA           0       389.0            73                1              1     g1              1
AATGTTGACAGTCA           0       100.0            41                0              0     g1              0
...                    ...         ...           ...              ...            ...    ...            ...
TTACGTACGTTCAG           0       228.0            39                0              0     g1              0
TTGAGGACTACGCA           0       787.0            88                0              0     g1              2
TTGCATTGAGCTAC           0       104.0            40                0              0     g2              2
TTGGTACTGAATCC           0       135.0            45                0              0     g1              2
TTTAGCTGTACTCT           0       462.0            86                1              1     g1              1

[80 rows x 7 columns]
```