### PR TITLE
Bump default goal-chunk-nnz for chunked X ingest

### DIFF
--- a/apis/python/src/tiledbsc/soma_options.py
+++ b/apis/python/src/tiledbsc/soma_options.py
@@ -28,7 +28,7 @@ class SOMAOptions:
         X_cell_order="row-major",
         string_dim_zstd_level=22,  # https://github.com/single-cell-data/TileDB-SingleCell/issues/27
         write_X_chunked=True,
-        goal_chunk_nnz=10000000,
+        goal_chunk_nnz=100000000,
         member_uris_are_relative=None,  # Allows relocatability for local disk / S3, and correct behavior for TileDB Cloud
     ):
         self.obs_extent = obs_extent


### PR DESCRIPTION
Based on experiments with chunking and consolidation. We can write fewer, larger fragments without OOMing, with comparable query time.