### PR TITLE
Improve clang-format checking

### DIFF
--- a/libtiledbsc/cmake/Superbuild.cmake
+++ b/libtiledbsc/cmake/Superbuild.cmake
@@ -84,14 +84,12 @@ find_package(ClangTools)
 if (${CLANG_FORMAT_FOUND})
   # Runs clang-format and updates files in place.
   add_custom_target(format ${SCRIPTS_DIR}/run-clang-format.sh ${CMAKE_CURRENT_SOURCE_DIR}/src ${CLANG_FORMAT_BIN} 1
-    `find ${CMAKE_CURRENT_SOURCE_DIR}/src ${CMAKE_CURRENT_SOURCE_DIR}/test
-    -name \\*.cc -or -name \\*.c -or -name \\*.h`)
+    `find ${CMAKE_CURRENT_SOURCE_DIR} -name \\*.cc -or -name \\*.c -or -name \\*.h`)
 
   # Runs clang-format and exits with a non-zero exit code# if any files need to
   # be reformatted
   add_custom_target(check-format ${SCRIPTS_DIR}/run-clang-format.sh ${CMAKE_CURRENT_SOURCE_DIR}/src ${CLANG_FORMAT_BIN} 0
-    `find ${CMAKE_CURRENT_SOURCE_DIR}/src ${CMAKE_CURRENT_SOURCE_DIR}/test
-    -name \\*.cc -or -name \\*.c -or -name \\*.h`)
+    `find ${CMAKE_CURRENT_SOURCE_DIR} -name \\*.cc -or -name \\*.c -or -name \\*.h`)
 endif()
 
 ############################################################

--- a/libtiledbsc/include/tiledbsc/buffer_set.h
+++ b/libtiledbsc/include/tiledbsc/buffer_set.h
@@ -3,12 +3,12 @@
 
 #include "tiledbsc_export.h"
 
-#include <vector>
-#include <string>
 #include <memory>
 #include <optional>
 #include <span>
 #include <stdexcept>
+#include <string>
+#include <vector>
 
 #include <tiledb/tiledb>
 
@@ -27,7 +27,7 @@ using DELEM_T = std::byte;
  * may not be initialized depending on the schema.
  */
 class TILEDBSC_EXPORT BufferSet {
-public:
+   public:
     BufferSet(
         const std::string& name,
         tiledb_datatype_t datatype,
@@ -35,18 +35,15 @@ public:
         std::vector<DELEM_T> data,
         std::optional<std::vector<uint64_t>> offsets,
         std::optional<std::vector<DELEM_T>> validity,
-        bool convert_bitmap = false
-    );
+        bool convert_bitmap = false);
 
     ~BufferSet();
 
     static BufferSet from_attribute(
-        const tiledb::Attribute& attr, size_t data_nelem
-    );
+        const tiledb::Attribute& attr, size_t data_nelem);
 
     static BufferSet from_dimension(
-        const tiledb::Dimension& attr, size_t data_nelem
-    );
+        const tiledb::Dimension& attr, size_t data_nelem);
 
     /**
      * Construct a BufferSet from data.
@@ -59,8 +56,7 @@ public:
         size_t elem_nbytes,
         std::span<std::byte> data,
         std::optional<std::span<uint64_t>> offsets = std::nullopt,
-        std::optional<std::span<std::byte>> validity = std::nullopt
-    );
+        std::optional<std::span<std::byte>> validity = std::nullopt);
 
     /**
      * Construct desired BufferSet with initial element count.
@@ -95,7 +91,8 @@ public:
      * Resize the buffer set hold `new_size` data *elements*
      * and optionally `new_ncells` *cells* (offsets, validity)
      */
-    void resize(size_t new_data_nelem, std::optional<size_t> new_ncells = std::nullopt);
+    void resize(
+        size_t new_data_nelem, std::optional<size_t> new_ncells = std::nullopt);
 
     /**
      * Returns true if the buffer set represents a variable-length field
@@ -155,6 +152,6 @@ public:
     std::optional<std::vector<DELEM_T>> validity_;
 };
 
-}; // namespace tiledb
+};  // namespace tiledbsc
 
 #endif

--- a/libtiledbsc/include/tiledbsc/carrow.h
+++ b/libtiledbsc/include/tiledbsc/carrow.h
@@ -12,37 +12,37 @@
 #define ARROW_FLAG_MAP_KEYS_SORTED 4
 
 struct ArrowSchema {
-  // Array type description
-  const char* format;
-  const char* name;
-  const char* metadata;
-  int64_t flags;
-  int64_t n_children;
-  struct ArrowSchema** children;
-  struct ArrowSchema* dictionary;
+    // Array type description
+    const char* format;
+    const char* name;
+    const char* metadata;
+    int64_t flags;
+    int64_t n_children;
+    struct ArrowSchema** children;
+    struct ArrowSchema* dictionary;
 
-  // Release callback
-  void (*release)(struct ArrowSchema*);
-  // Opaque producer-specific data
-  void* private_data;
+    // Release callback
+    void (*release)(struct ArrowSchema*);
+    // Opaque producer-specific data
+    void* private_data;
 };
 
 struct ArrowArray {
-  // Array data description
-  int64_t length;
-  int64_t null_count;
-  int64_t offset;
-  int64_t n_buffers;
-  int64_t n_children;
-  const void** buffers;
-  struct ArrowArray** children;
-  struct ArrowArray* dictionary;
+    // Array data description
+    int64_t length;
+    int64_t null_count;
+    int64_t offset;
+    int64_t n_buffers;
+    int64_t n_children;
+    const void** buffers;
+    struct ArrowArray** children;
+    struct ArrowArray* dictionary;
 
-  // Release callback
-  void (*release)(struct ArrowArray*);
-  // Opaque producer-specific data
-  void* private_data;
+    // Release callback
+    void (*release)(struct ArrowArray*);
+    // Opaque producer-specific data
+    void* private_data;
 };
 /* End Arrow C API */
 /* ************************************************************************ */
-#endif // TILEDBSC_CARROW_H
+#endif  // TILEDBSC_CARROW_H

--- a/libtiledbsc/include/tiledbsc/common.h
+++ b/libtiledbsc/include/tiledbsc/common.h
@@ -1,8 +1,8 @@
 #ifndef TILEDBSC_COMMON_H
 #define TILEDBSC_COMMON_H
 
-#include <stdexcept>
 #include <map>
+#include <stdexcept>
 #include <string>
 
 #include "tiledbsc_export.h"
@@ -14,16 +14,18 @@ using SCConfig = std::map<std::string, std::string>;
 using DELEM_T = std::byte;
 
 class TileDBSCError : public std::runtime_error {
-public:
-  explicit TileDBSCError(const char *m) : std::runtime_error(m) {};
-  explicit TileDBSCError(std::string m) : std::runtime_error(m.c_str()) {};
+   public:
+    explicit TileDBSCError(const char* m)
+        : std::runtime_error(m){};
+    explicit TileDBSCError(std::string m)
+        : std::runtime_error(m.c_str()){};
 
-public:
-  virtual const char *what() const noexcept override {
-    return std::runtime_error::what();
-  };
+   public:
+    virtual const char* what() const noexcept override {
+        return std::runtime_error::what();
+    };
 };
 
-}; // namespace tiledbsc
+};  // namespace tiledbsc
 
-#endif // TILEDBSC_COMMON_H
+#endif  // TILEDBSC_COMMON_H

--- a/libtiledbsc/include/tiledbsc/generic_typed_vector.h
+++ b/libtiledbsc/include/tiledbsc/generic_typed_vector.h
@@ -1,12 +1,12 @@
 namespace tiledbsc {
 
 class generic_typed_vector {
-//
-//    generic_typed_vector(
-//        TypeTag T,
-//        size_t size
-//
-//    ) : type_tag_(T), size_(size) {}
+    //
+    //    generic_typed_vector(
+    //        TypeTag T,
+    //        size_t size
+    //
+    //    ) : type_tag_(T), size_(size) {}
 };
 
-}; // namespace tiledbsc
+};  // namespace tiledbsc

--- a/libtiledbsc/include/tiledbsc/ij_query.h
+++ b/libtiledbsc/include/tiledbsc/ij_query.h
@@ -8,10 +8,9 @@
 
 #include <tiledb/tiledb>
 
-#include <tiledbsc/managed_query.h>
 #include <tiledbsc/buffer_set.h>
 #include <tiledbsc/generic_typed_vector.h>
-
+#include <tiledbsc/managed_query.h>
 
 using namespace tiledbsc;
 using namespace tiledb;
@@ -33,22 +32,21 @@ namespace tiledbsc {
  */
 
 class TILEDBSC_EXPORT IJQuery {
-public:
+   public:
     IJQuery(
         const shared_ptr<tiledb::Array> reference,
-        pair<string,string> ref_pair,
+        pair<string, string> ref_pair,
         const shared_ptr<tiledb::Array> target,
-        string dest_name
-    );
+        string dest_name);
 
     ~IJQuery();
 
     unique_ptr<QueryResult> select_from_points(generic_typed_vector v);
 
-private:
+   private:
     void check_compatible();
 
-private:
+   private:
     const shared_ptr<tiledb::Array> array_ref_;
     const string ref_dim_;
     const string ref_attr_;
@@ -56,6 +54,6 @@ private:
     std::string tgt_dim_;
 };
 
-}; // namespace tiledbsc
+};  // namespace tiledbsc
 
-#endif // TILEDBSC_IJQUERY_H
+#endif  // TILEDBSC_IJQUERY_H

--- a/libtiledbsc/include/tiledbsc/managed_query.h
+++ b/libtiledbsc/include/tiledbsc/managed_query.h
@@ -4,11 +4,10 @@
 #include <memory>
 #include <vector>
 
-#include <tiledb/tiledb>
 #include <tiledbsc/query_result.h>
+#include <tiledb/tiledb>
 
 #include "tiledbsc_export.h"
-
 
 namespace tiledbsc {
 
@@ -17,7 +16,6 @@ using namespace std;
 // TODO use allocator which does not zero initialize
 // TODO config - 4 MB
 constexpr size_t TILEDBSC_DEFAULT_ALLOC = 524288;
-
 
 // Forward declaration
 class MQAux;
@@ -29,8 +27,7 @@ class MQAux;
  *
  */
 class TILEDBSC_EXPORT ManagedQuery {
-
-public:
+   public:
     ManagedQuery(
         const std::shared_ptr<tiledb::Array> array,
         size_t initial_alloc = TILEDBSC_DEFAULT_ALLOC);
@@ -71,9 +68,10 @@ public:
      */
     size_t initial_ncells();
 
-private:
+   private:
     /* methods */
-    static std::shared_ptr<tiledb::Array> check_array(std::shared_ptr<tiledb::Array>);
+    static std::shared_ptr<tiledb::Array> check_array(
+        std::shared_ptr<tiledb::Array>);
 
     void allocate_buffers();
     void set_buffers();
@@ -100,6 +98,6 @@ private:
     std::unique_ptr<MQAux> impl_;
 };
 
-};
+};  // namespace tiledbsc
 
 #endif

--- a/libtiledbsc/include/tiledbsc/query_result.h
+++ b/libtiledbsc/include/tiledbsc/query_result.h
@@ -4,7 +4,7 @@
 #include <memory>
 #include <vector>
 
-#include <stdexcept> // required for TileDB, bug
+#include <stdexcept>  // required for TileDB, bug
 
 #include <tiledb/tiledb>
 
@@ -13,21 +13,21 @@
 
 #include "tiledbsc_export.h"
 
-
 namespace tiledbsc {
 
-//namespace arrow {
-//    struct ArrowPair;
-//}
+// namespace arrow {
+//     struct ArrowPair;
+// }
 
 using namespace std;
 
-using ResultBuffers = map<string,BufferSet>;
+using ResultBuffers = map<string, BufferSet>;
 
 class TILEDBSC_EXPORT QueryResult {
-public:
+   public:
     QueryResult() = delete;
-    QueryResult(ResultBuffers&& buffers) : buffers_(std::move(buffers)) {};
+    QueryResult(ResultBuffers&& buffers)
+        : buffers_(std::move(buffers)){};
     ResultBuffers& buffers();
 
     tiledbsc::arrow::ArrowPair to_arrow(std::optional<std::string>);
@@ -40,10 +40,10 @@ public:
 
     std::vector<std::string> names();
 
-private:
+   private:
     ResultBuffers buffers_;
 };
 
-}; // namespace tiledbsc
+};  // namespace tiledbsc
 
-#endif // TILEDBSC_QUERY_RESULT_H
+#endif  // TILEDBSC_QUERY_RESULT_H

--- a/libtiledbsc/include/tiledbsc/sc_arrowio.h
+++ b/libtiledbsc/include/tiledbsc/sc_arrowio.h
@@ -1,7 +1,6 @@
 #ifndef TILEDBSC_ARROW_H
 #define TILEDBSC_ARROW_H
 
-
 /**      -*-C++-*-
  * vim: set ft=cpp:
  * @file   arrowio
@@ -37,9 +36,8 @@
 
 #include <memory>
 
-#include <tiledbsc/query_result.h>
 #include <tiledbsc/carrow.h>
-
+#include <tiledbsc/query_result.h>
 
 namespace tiledbsc {
 
@@ -56,23 +54,25 @@ struct TILEDBSC_EXPORT ArrowPair {
     ArrowArray* array;
     bool own_;
 
-    ArrowPair() : own_(true) {
-      schema = (ArrowSchema*)malloc(sizeof(ArrowSchema));
-      array = (ArrowArray*)malloc(sizeof(ArrowArray));
+    ArrowPair()
+        : own_(true) {
+        schema = (ArrowSchema*)malloc(sizeof(ArrowSchema));
+        array = (ArrowArray*)malloc(sizeof(ArrowArray));
 
-      if (!schema || !array)
-        throw std::runtime_error("Failed to allocate ArrowSchema and ArrowArray structs");
+        if (!schema || !array)
+            throw std::runtime_error(
+                "Failed to allocate ArrowSchema and ArrowArray structs");
     }
 
     ~ArrowPair() {
-      if (own_) {
-        free(schema);
-        free(array);
-      }
+        if (own_) {
+            free(schema);
+            free(array);
+        }
     }
 
     void disown() {
-      own_ = false;
+        own_ = false;
     }
 };
 
@@ -87,62 +87,66 @@ struct TILEDBSC_EXPORT ArrowPair {
  *
  */
 class TILEDBSC_EXPORT ArrowAdapter {
-public:
-  /* Constructs an ArrowAdapter wrapping the given QueryResult */
-  ArrowAdapter(tiledbsc::QueryResult& qr);
-  ~ArrowAdapter();
+   public:
+    /* Constructs an ArrowAdapter wrapping the given QueryResult */
+    ArrowAdapter(tiledbsc::QueryResult& qr);
+    ~ArrowAdapter();
 
-  /**
-   * Exports named Query buffer to ArrowArray/ArrowSchema struct pair,
-   * as defined in the Arrow C Data Interface.
-   *
-   * @param name The name of the buffer to export.
-   * @param arrow_array Pointer to pre-allocated ArrowArray struct
-   * @param arrow_schema Pointer to pre-allocated ArrowSchema struct
-   * @throws tiledb::TileDBError with error-specific message.
-   */
-  void export_array(const char* name, void* arrow_array, void* arrow_schema);
+    /**
+     * Exports named Query buffer to ArrowArray/ArrowSchema struct pair,
+     * as defined in the Arrow C Data Interface.
+     *
+     * @param name The name of the buffer to export.
+     * @param arrow_array Pointer to pre-allocated ArrowArray struct
+     * @param arrow_schema Pointer to pre-allocated ArrowSchema struct
+     * @throws tiledb::TileDBError with error-specific message.
+     */
+    void export_array(const char* name, void* arrow_array, void* arrow_schema);
 
-   /**
-   * Exports given BufferSet to ArrowArray/ArrowSchema struct pair,
-   * as defined in the Arrow C Data Interface.
-   *
-   * @param BufferSet The BufferSet to export.
-   * @param arrow_array Pointer to pre-allocated ArrowArray struct
-   * @param arrow_schema Pointer to pre-allocated ArrowSchema struct
-   * @throws tiledb::TileDBError with error-specific message.
-   */
-  static void export_buffer(BufferSet& buffer_set, ArrowArray* arrow_array, ArrowSchema* arrow_schema);
+    /**
+     * Exports given BufferSet to ArrowArray/ArrowSchema struct pair,
+     * as defined in the Arrow C Data Interface.
+     *
+     * @param BufferSet The BufferSet to export.
+     * @param arrow_array Pointer to pre-allocated ArrowArray struct
+     * @param arrow_schema Pointer to pre-allocated ArrowSchema struct
+     * @throws tiledb::TileDBError with error-specific message.
+     */
+    static void export_buffer(
+        BufferSet& buffer_set,
+        ArrowArray* arrow_array,
+        ArrowSchema* arrow_schema);
 
-  /**
-   * Exports *all* results in QueryResults to ArrowArray/ArrowSchema
-   *
-   * @param arrow_array Pointer to pre-allocated ArrowArray struct
-   * @param arrow_schema Pointer to pre-allocated ArrowSchema struct
-   * @throws tiledb::TileDBError with error-specific message.
-   */
-  void export_table(void* arrow_array, void* arrow_schema);
+    /**
+     * Exports *all* results in QueryResults to ArrowArray/ArrowSchema
+     *
+     * @param arrow_array Pointer to pre-allocated ArrowArray struct
+     * @param arrow_schema Pointer to pre-allocated ArrowSchema struct
+     * @throws tiledb::TileDBError with error-specific message.
+     */
+    void export_table(void* arrow_array, void* arrow_schema);
 
-  /**
-   * Set named Query buffer from ArrowArray/ArrowSchema struct pair
-   * representing external data buffers conforming to the
-   * Arrow C Data Interface.
-   *
-   * @param name The name of the buffer to export.
-   * @param arrow_array Pointer to pre-allocated ArrowArray struct
-   * @param arrow_schema Pointer to pre-allocated ArrowSchema struct
-   * @throws tiledb::TileDBError with error-specific message.
-   */
-  //void import_buffer(const char* name, void* arrow_array, void* arrow_schema);
+    /**
+     * Set named Query buffer from ArrowArray/ArrowSchema struct pair
+     * representing external data buffers conforming to the
+     * Arrow C Data Interface.
+     *
+     * @param name The name of the buffer to export.
+     * @param arrow_array Pointer to pre-allocated ArrowArray struct
+     * @param arrow_schema Pointer to pre-allocated ArrowSchema struct
+     * @throws tiledb::TileDBError with error-specific message.
+     */
+    // void import_buffer(const char* name, void* arrow_array, void*
+    // arrow_schema);
 
-private:
-  //ArrowImporter* importer_;
-  ArrowExporter* exporter_;
+   private:
+    // ArrowImporter* importer_;
+    ArrowExporter* exporter_;
 };
 
 }  // end namespace arrow
-}  // end namespace tiledb
+}  // namespace tiledbsc
 
 //#include "arrow_io_impl.h"
 
-#endif // TILEDBSC_ARROW_H
+#endif  // TILEDBSC_ARROW_H

--- a/libtiledbsc/include/tiledbsc/tiledbsc.h
+++ b/libtiledbsc/include/tiledbsc/tiledbsc.h
@@ -16,7 +16,6 @@
 #include <tiledbsc/common.h>
 #include <tiledbsc/managed_query.h>
 
-
 namespace tiledbsc {
 
 using namespace tiledb;
@@ -40,10 +39,10 @@ struct SCResult {
      *        results to a BufferSet (buffer composition depends on
      *        attribute type).
      *
-     * @throws TileDBSCError if the array is already open or other error occurred.
+     * @throws TileDBSCError if the array is already open or other error
+     * occurred.
      */
     std::shared_ptr<QueryResult> query_result();
-
 
     /*** Arrow API ***/
     /**
@@ -51,22 +50,22 @@ struct SCResult {
      *        results to a BufferSet (buffer composition depends on
      *        attribute type).
      *
-     * @throws TileDBSCError if the array is already open or other error occurred.
+     * @throws TileDBSCError if the array is already open or other error
+     * occurred.
      */
     void to_arrow(void* schema, void* array);
-
 
     /**
      * @brief Returns the BufferGroup mapping dimension and attribute
      *        results to a BufferSet (buffer composition depends on
      *        attribute type).
      *
-     * @throws TileDBSCError if the array is already open or other error occurred.
+     * @throws TileDBSCError if the array is already open or other error
+     * occurred.
      */
     void release_callback(void* user_data);
 
-
-    private:
+   private:
     /* ********************************* */
     /*         PRIVATE ATTRIBUTES        */
     /* ********************************* */
@@ -74,7 +73,6 @@ struct SCResult {
     ResultBuffers buffers_;
 };
 
+};  // end namespace tiledbsc
 
-}; // end namespace tiledbsc
-
-#endif // TILEDBSC_H
+#endif  // TILEDBSC_H

--- a/libtiledbsc/include/tiledbsc/util.h
+++ b/libtiledbsc/include/tiledbsc/util.h
@@ -1,9 +1,9 @@
 #include "tiledbsc_export.h"
 
-#include <string>
-#include <vector>
 #include <optional>
 #include <span>
+#include <string>
+#include <vector>
 
 #include <tiledbsc/common.h>
 
@@ -11,14 +11,13 @@ using namespace std;
 
 namespace tiledbsc::util {
 
-TILEDBSC_EXPORT void check_paths_exist(vector<string>, optional<SCConfig> config);
+TILEDBSC_EXPORT void check_paths_exist(
+    vector<string>, optional<SCConfig> config);
 
-using VarlenBufferPair = pair< vector<DELEM_T>, vector<uint64_t> >;
+using VarlenBufferPair = pair<vector<DELEM_T>, vector<uint64_t>>;
 
 template <typename T>
-TILEDBSC_EXPORT VarlenBufferPair to_varlen_buffers(
-    vector<T> data
-);
+TILEDBSC_EXPORT VarlenBufferPair to_varlen_buffers(vector<T> data);
 
 /**
  * Convert bytemap vector to bitmap in-place. Initial size() elements will
@@ -31,4 +30,4 @@ TILEDBSC_EXPORT VarlenBufferPair to_varlen_buffers(
 TILEDBSC_EXPORT size_t bytemap_to_bitmap_inplace(std::span<uint8_t> bytemap);
 TILEDBSC_EXPORT size_t bytemap_to_bitmap_inplace(std::span<byte> bytemap);
 
-} // end namespace tiledb::util
+}  // namespace tiledbsc::util

--- a/libtiledbsc/src/soma_collection.cc
+++ b/libtiledbsc/src/soma_collection.cc
@@ -57,7 +57,8 @@ void SOMACollection::build_uri_map(Group& group, std::string_view parent) {
             bool subgroup_is_soma;
             if (value) {
                 // Found metadata, check if object_type is "SOMA"
-                std::string object_type(static_cast<const char*>(value));
+                std::string_view object_type(
+                    static_cast<const char*>(value), value_num);
                 subgroup_is_soma = object_type == "SOMA";
             } else {
                 // Metadata not found, infer the group is a SOMA if it contains

--- a/scripts/test
+++ b/scripts/test
@@ -7,7 +7,7 @@ set -eu -o pipefail
 # cd to the top level directory of the repo
 cd $(git rev-parse --show-toplevel)
 
-cmake --build build/libtiledbsc --target unit_managed_query
-cmake --build build/libtiledbsc --target unit_buffer_set
-cmake --build build/libtiledbsc --target unit_sc
-cmake --build build/libtiledbsc --target test
+cmake --build build/libtiledbsc --target build_tests -j $(nproc)
+
+cd build/libtiledbsc
+ctest -C Release

--- a/scripts/test
+++ b/scripts/test
@@ -10,4 +10,4 @@ cd $(git rev-parse --show-toplevel)
 cmake --build build/libtiledbsc --target build_tests -j $(nproc)
 
 cd build/libtiledbsc
-ctest -C Release
+ctest -C Release --verbose


### PR DESCRIPTION
* Update the clang-format check to find all source files
* Update source files missed with the previous `make format`
* Fix a bug in reading group metadata