### PR TITLE
Coalesce two dataframe methods into one

### DIFF
--- a/apis/python/src/tiledbsc/annotation_dataframe.py
+++ b/apis/python/src/tiledbsc/annotation_dataframe.py
@@ -251,26 +251,3 @@ class AnnotationDataFrame(TileDBArray):
 
         if self._verbose:
             print(util.format_elapsed(s, f"{self._indent}FINISH WRITING {self.uri}"))
-
-    # ----------------------------------------------------------------
-    def to_dataframe(self) -> pd.DataFrame:
-        """
-        Reads the TileDB `obs` or `var` array and returns a type of pandas dataframe
-        and dimension values.
-        """
-
-        if self._verbose:
-            s = util.get_start_stamp()
-            print(f"{self._indent}START  read {self.uri}")
-
-        with tiledb.open(self.uri, ctx=self._ctx) as A:
-            # We could use A.df[:] to set the index_name to 'obs_id' or 'var_id'.
-            # However, the resulting dataframe has obs_id/var_id as strings, not
-            # bytes, resulting in `KeyError` elsewhere in the code.
-            df = pd.DataFrame(A[:])
-            df = df.set_index(self.dim_name)
-
-        if self._verbose:
-            print(util.format_elapsed(s, f"{self._indent}FINISH read {self.uri}"))
-
-        return df

--- a/apis/python/src/tiledbsc/assay_matrix.py
+++ b/apis/python/src/tiledbsc/assay_matrix.py
@@ -546,12 +546,7 @@ class AssayMatrix(TileDBArray):
             s = util.get_start_stamp()
             print(f"{self._indent}START  read {self.uri}")
 
-        # Since the TileDB array is sparse, with two string dimensions, we get back a dict:
-        # * 'obs_id' key is a sequence of dim0 coordinates for X data.
-        # * 'var_id' key is a sequence of dim1 coordinates for X data.
-        # * 'values' key is a sequence of X data values.
-        with tiledb.open(self.uri, ctx=self._ctx) as A:
-            df = A[:]
+        df = self.df()
 
         retval = util._X_and_ids_to_coo(
             df,

--- a/apis/python/src/tiledbsc/assay_matrix.py
+++ b/apis/python/src/tiledbsc/assay_matrix.py
@@ -80,7 +80,7 @@ class AssayMatrix(TileDBArray):
             return (num_rows, num_cols)
 
     # ----------------------------------------------------------------
-    def dim_select(self, obs_ids, var_ids):
+    def dim_select(self, obs_ids, var_ids) -> pd.DataFrame:
         """
         Selects a slice out of the matrix with specified `obs_ids` and/or `var_ids`.
         Either or both of the ID lists may be `None`, meaning, do not subselect along
@@ -548,13 +548,14 @@ class AssayMatrix(TileDBArray):
 
         df = self.df()
 
-        retval = util._X_and_ids_to_coo(
+        retval = util.X_and_ids_to_sparse_matrix(
             df,
             self.row_dim_name,
             self.col_dim_name,
             self.attr_name,
             row_labels,
             col_labels,
+            return_as="csr",
         )
 
         if self._verbose:

--- a/apis/python/src/tiledbsc/io/anndata.py
+++ b/apis/python/src/tiledbsc/io/anndata.py
@@ -241,8 +241,8 @@ def to_anndata(soma: tiledbsc.SOMA) -> ad.AnnData:
         s = tiledbsc.util.get_start_stamp()
         print(f"START  SOMA.to_anndata {soma.uri}")
 
-    obs_df = soma.obs.to_dataframe()
-    var_df = soma.var.to_dataframe()
+    obs_df = soma.obs.df()
+    var_df = soma.var.df()
 
     X_mat = soma.X["data"].to_csr_matrix(obs_df.index, var_df.index)
 
@@ -292,8 +292,8 @@ def to_anndata_from_raw(soma: tiledbsc.SOMA) -> ad.AnnData:
     Extract only the raw parts as a new AnnData object.
     """
 
-    obs_df = soma.obs.to_dataframe()
-    var_df = soma.raw.var.to_dataframe()
+    obs_df = soma.obs.df()
+    var_df = soma.raw.var.df()
     X_mat = soma.raw.X["data"].to_csr_matrix(obs.index, var.index)
 
     return ad.AnnData(

--- a/apis/python/src/tiledbsc/raw_group.py
+++ b/apis/python/src/tiledbsc/raw_group.py
@@ -95,7 +95,7 @@ class RawGroup(TileDBGroup):
         The `obs_labels` must be from the parent object.
         """
 
-        var_df = self.var.to_dataframe()
+        var_df = self.var.df()
         X_mat = self.X["data"].to_csr_matrix(obs_labels, var_df.index)
         varm = self.varm.to_dict_of_csr()
 

--- a/apis/python/src/tiledbsc/util.py
+++ b/apis/python/src/tiledbsc/util.py
@@ -199,8 +199,8 @@ def _X_and_ids_to_coo(
     row_dim_name: str,
     col_dim_name: str,
     attr_name: str,
-    row_labels,
-    col_labels,
+    row_labels: List[str],
+    col_labels: List[str],
 ) -> scipy.sparse.csr_matrix:
     """
     This is needed when we read a TileDB X.df[:]. Since TileDB X is sparse 2D string-dimensioned,
@@ -208,6 +208,10 @@ def _X_and_ids_to_coo(
     conversion to anndata, we need make a sparse COO/IJV-format array where the indices are
     not strings but ints, matching the obs and var labels.
     """
+
+    assert isinstance(Xdf, pd.DataFrame)
+    assert len(row_labels) > 0 and isinstance(row_labels[0], str)
+    assert len(col_labels) > 0 and isinstance(col_labels[0], str)
 
     # Now we need to convert from TileDB's string indices to CSR integer indices.
     # Make a dict from string dimension values to integer indices.
@@ -233,7 +237,9 @@ def _X_and_ids_to_coo(
     row_labels_to_indices = dict(zip(row_labels, [i for i, e in enumerate(row_labels)]))
     col_labels_to_indices = dict(zip(col_labels, [i for i, e in enumerate(col_labels)]))
 
-    # Apply the map.
+    # Make the obs_id/var_id indices addressable as columns.
+    Xdf.reset_index(inplace=True)
+
     obs_indices = [row_labels_to_indices[row_label] for row_label in Xdf[row_dim_name]]
     var_indices = [col_labels_to_indices[col_label] for col_label in Xdf[col_dim_name]]
 

--- a/apis/python/src/tiledbsc/util.py
+++ b/apis/python/src/tiledbsc/util.py
@@ -7,7 +7,7 @@ import scipy
 import pandas as pd
 
 import time
-from typing import Optional, List
+from typing import Optional, List, Union
 
 # ----------------------------------------------------------------
 def is_local_path(path: str) -> bool:
@@ -194,24 +194,27 @@ def _to_tiledb_supported_array_type(x):
 
 
 # ----------------------------------------------------------------
-def _X_and_ids_to_coo(
+def X_and_ids_to_sparse_matrix(
     Xdf: pd.DataFrame,
     row_dim_name: str,
     col_dim_name: str,
     attr_name: str,
     row_labels: List[str],
     col_labels: List[str],
-) -> scipy.sparse.csr_matrix:
+    return_as: str = "csr",
+) -> Union[scipy.sparse.csr_matrix, scipy.sparse.csc_matrix]:
     """
     This is needed when we read a TileDB X.df[:]. Since TileDB X is sparse 2D string-dimensioned,
     the return value of which is a dict with three columns -- obs_id, var_id, and value. For
     conversion to anndata, we need make a sparse COO/IJV-format array where the indices are
     not strings but ints, matching the obs and var labels.
+    The `return_as` parameter must be one of `"csr"` or `"csc"`.
     """
 
     assert isinstance(Xdf, pd.DataFrame)
     assert len(row_labels) > 0 and isinstance(row_labels[0], str)
     assert len(col_labels) > 0 and isinstance(col_labels[0], str)
+    assert return_as in ["csr", "csc"]
 
     # Now we need to convert from TileDB's string indices to CSR integer indices.
     # Make a dict from string dimension values to integer indices.
@@ -243,9 +246,13 @@ def _X_and_ids_to_coo(
     obs_indices = [row_labels_to_indices[row_label] for row_label in Xdf[row_dim_name]]
     var_indices = [col_labels_to_indices[col_label] for col_label in Xdf[col_dim_name]]
 
-    return scipy.sparse.csr_matrix(
-        (list(Xdf[attr_name]), (list(obs_indices), list(var_indices)))
-    )
+    xcol = list(Xdf[attr_name])
+    ocol = list(obs_indices)
+    vcol = list(var_indices)
+    if return_as == "csr":
+        return scipy.sparse.csr_matrix((xcol, (ocol, vcol)))
+    else:
+        return scipy.sparse.csc_matrix((xcol, (ocol, vcol)))
 
 
 # ================================================================


### PR DESCRIPTION
We had two dataframe methods; there should be just one.

Moreover this makes for a nice API enhancement used by @ebezzi . Namely:

```
>>> df = soma.X['data'].dim_select(None,['AKR1C3','VDAC3'])

>>> csr = tiledbsc.util.X_and_ids_to_sparse_matrix(df, 'obs_id', 'var_id', 'value', soma.obs.ids(), soma.var.ids())

>>> csr.shape
(80, 20)

>>> csr.mean(axis=1).shape
(80, 1)
```