### PR TITLE
Ensure sliced matrices are correctly dimensioned

### DIFF
--- a/apis/python/src/tiledbsc/annotation_dataframe.py
+++ b/apis/python/src/tiledbsc/annotation_dataframe.py
@@ -125,7 +125,7 @@ class AnnotationDataFrame(TileDBArray):
         `cell_type == "blood"`. Returns None if the slice is empty.
         This is a v1 implementation for the prototype/demo timeframe.
         """
-        with tiledb.open(self.uri, ctx=self._ctx) as A:
+        with self._open() as A:
             qc = tiledb.QueryCondition(query_string)
             slice_query = A.query(attr_cond=qc)
             slice_df = slice_query.df[:][col_names_to_keep]

--- a/apis/python/src/tiledbsc/assay_matrix.py
+++ b/apis/python/src/tiledbsc/assay_matrix.py
@@ -113,26 +113,19 @@ class AssayMatrix(TileDBArray):
         """
         Like `.df()` but returns results in `scipy.sparse.csr_matrix` format.
         """
-        df = self.dim_select(obs_ids, var_ids)
-        if obs_ids is None:
-            obs_ids = self.row_dataframe.ids()
-        if var_ids is None:
-            var_ids = self.col_dataframe.ids()
-        return util.X_and_ids_to_sparse_matrix(
-            df,
-            self.row_dim_name,
-            self.col_dim_name,
-            self.attr_name,
-            obs_ids,
-            var_ids,
-            "csr",
-        )
+        return self._csr_or_csc("csr", obs_ids, var_ids)
 
-    # ----------------------------------------------------------------
     def csc(self, obs_ids=None, var_ids=None) -> scipy.sparse.csc_matrix:
         """
         Like `.df()` but returns results in `scipy.sparse.csc_matrix` format.
         """
+        return self._csr_or_csc("csc", obs_ids, var_ids)
+
+    def _csr_or_csc(self, which: str, obs_ids=None, var_ids=None):
+        """
+        Helper method for `csr` and `csc`.
+        """
+        assert which in ("csr", "csc")
         df = self.dim_select(obs_ids, var_ids)
         if obs_ids is None:
             obs_ids = self.row_dataframe.ids()
@@ -145,7 +138,7 @@ class AssayMatrix(TileDBArray):
             self.attr_name,
             obs_ids,
             var_ids,
-            "csc",
+            which,
         )
 
     # ----------------------------------------------------------------

--- a/apis/python/src/tiledbsc/assay_matrix.py
+++ b/apis/python/src/tiledbsc/assay_matrix.py
@@ -109,6 +109,46 @@ class AssayMatrix(TileDBArray):
         return self.dim_select(obs_ids, var_ids)
 
     # ----------------------------------------------------------------
+    def csr(self, obs_ids=None, var_ids=None) -> scipy.sparse.csr_matrix:
+        """
+        Like `.df()` but returns results in `scipy.sparse.csr_matrix` format.
+        """
+        df = self.dim_select(obs_ids, var_ids)
+        if obs_ids is None:
+            obs_ids = self.row_dataframe.ids()
+        if var_ids is None:
+            var_ids = self.col_dataframe.ids()
+        return util.X_and_ids_to_sparse_matrix(
+            df,
+            self.row_dim_name,
+            self.col_dim_name,
+            self.attr_name,
+            obs_ids,
+            var_ids,
+            "csr",
+        )
+
+    # ----------------------------------------------------------------
+    def csc(self, obs_ids=None, var_ids=None) -> scipy.sparse.csc_matrix:
+        """
+        Like `.df()` but returns results in `scipy.sparse.csc_matrix` format.
+        """
+        df = self.dim_select(obs_ids, var_ids)
+        if obs_ids is None:
+            obs_ids = self.row_dataframe.ids()
+        if var_ids is None:
+            var_ids = self.col_dataframe.ids()
+        return util.X_and_ids_to_sparse_matrix(
+            df,
+            self.row_dim_name,
+            self.col_dim_name,
+            self.attr_name,
+            obs_ids,
+            var_ids,
+            "csc",
+        )
+
+    # ----------------------------------------------------------------
     def from_matrix_and_dim_values(self, matrix, row_names, col_names) -> None:
         """
         Imports a matrix -- nominally `scipy.sparse.csr_matrix` or `numpy.ndarray` -- into a TileDB
@@ -118,6 +158,9 @@ class AssayMatrix(TileDBArray):
         if self._verbose:
             s = util.get_start_stamp()
             print(f"{self._indent}START  WRITING {self.uri}")
+
+        assert len(row_names) == matrix.shape[0]
+        assert len(col_names) == matrix.shape[1]
 
         if self.exists():
             if self._verbose:
@@ -291,6 +334,7 @@ class AssayMatrix(TileDBArray):
                 d1 = col_names[chunk_coo.col]
 
                 if len(d0) == 0:
+                    i = i2
                     continue
 
                 # Python ranges are (lo, hi) with lo inclusive and hi exclusive. But saying that
@@ -387,6 +431,7 @@ class AssayMatrix(TileDBArray):
                 d1 = sorted_col_names[chunk_coo.col + j]
 
                 if len(d1) == 0:
+                    j = j2
                     continue
 
                 # Python ranges are (lo, hi) with lo inclusive and hi exclusive. But saying that
@@ -487,6 +532,7 @@ class AssayMatrix(TileDBArray):
                 d1 = col_names[chunk_coo.col]
 
                 if len(d0) == 0:
+                    i = i2
                     continue
 
                 # Python ranges are (lo, hi) with lo inclusive and hi exclusive. But saying that

--- a/apis/python/src/tiledbsc/util.py
+++ b/apis/python/src/tiledbsc/util.py
@@ -249,10 +249,16 @@ def X_and_ids_to_sparse_matrix(
     xcol = list(Xdf[attr_name])
     ocol = list(obs_indices)
     vcol = list(var_indices)
+    # Explicitly write the shape to avoid trimming in case of all-zeroes rows/columns when
+    # people do dim-selects.
     if return_as == "csr":
-        return scipy.sparse.csr_matrix((xcol, (ocol, vcol)))
+        return scipy.sparse.csr_matrix(
+            (xcol, (ocol, vcol)), shape=(len(row_labels), len(col_labels))
+        )
     else:
-        return scipy.sparse.csc_matrix((xcol, (ocol, vcol)))
+        return scipy.sparse.csc_matrix(
+            (xcol, (ocol, vcol)), shape=(len(row_labels), len(col_labels))
+        )
 
 
 # ================================================================


### PR DESCRIPTION
Example from @ebezzi -- this occurs when dim-selecting on `X` matrices where the slice contains all-zero rows/columns.

Before:

```
$ peek-soma ~/Desktop/collab/bezzi/bezzi-soma

>>> var_df = soma.var.df()

>>> var_df[var_df.feature_name == "CLMP"]
                feature_biotype  feature_is_filtered feature_name feature_reference
var_id
ENSG00000166250            gene                    0         CLMP    NCBITaxon:9606

>>> var_ids = ['ENSG00000166250']

>>> xdf = soma.X.data.dim_select(obs_ids=None, var_ids=var_ids)

>>> csr = tiledbsc.util.X_and_ids_to_sparse_matrix(xdf, 'obs_id', 'var_id', 'value', soma.obs.ids(), var_ids)

>>> csr.shape
(2092, 1)

>>> len(soma.obs.ids())
2113
```

After:

```
$ peek-soma ~/Desktop/collab/bezzi/bezzi-soma

>>> var_df = soma.var.df()

>>> var_df[var_df.feature_name == "CLMP"]
                feature_biotype  feature_is_filtered feature_name feature_reference
var_id
ENSG00000166250            gene                    0         CLMP    NCBITaxon:9606

>>> var_ids = ['ENSG00000166250']

>>> csr = soma.X.data.csr(obs_ids=None, var_ids=var_ids)

>>> csr.shape
(2113, 1)

>>> len(soma.obs.ids())
2113
```