### PR TITLE
#149 was overly ambitious

### DIFF
--- a/apis/python/src/tiledbsc/soma_options.py
+++ b/apis/python/src/tiledbsc/soma_options.py
@@ -28,7 +28,7 @@ class SOMAOptions:
         X_cell_order="row-major",
         string_dim_zstd_level=22,  # https://github.com/single-cell-data/TileDB-SingleCell/issues/27
         write_X_chunked=True,
-        goal_chunk_nnz=100000000,
+        goal_chunk_nnz=20_000_000,
         member_uris_are_relative=None,  # Allows relocatability for local disk / S3, and correct behavior for TileDB Cloud
     ):
         self.obs_extent = obs_extent


### PR DESCRIPTION
The goal was to up fragment sizes --

Before:

```
-rw-r--r--  1 johnkerl  staff    21M Jun  3 17:09 try-pre-consol/X/data/__fragments/__1654290548407_1654290548407_9d622d5ea1364b488cd9cf0ee9e44286_13/d1_var.tdb
-rw-r--r--  1 johnkerl  staff    21M Jun  3 17:09 try-pre-consol/X/data/__fragments/__1654290561536_1654290561536_6ac6853ea4774c28845614a9f1fba039_13/d1_var.tdb
-rw-r--r--  1 johnkerl  staff    21M Jun  3 17:12 try-pre-consol/X/data/__fragments/__1654290742771_1654290742771_9fe9df06edd14cdaba738ac70399fc2d_13/d1_var.tdb
-rw-r--r--  1 johnkerl  staff    21M Jun  3 17:07 try-pre-consol/X/data/__fragments/__1654290467666_1654290467666_c59a65e556334be0975d90248512740c_13/d1_var.tdb
-rw-r--r--  1 johnkerl  staff    21M Jun  3 17:08 try-pre-consol/X/data/__fragments/__1654290507071_1654290507071_c8088253d0d54ea1b793f7f8dcdfbdbe_13/d1_var.tdb
-rw-r--r--  1 johnkerl  staff    21M Jun  3 17:12 try-pre-consol/X/data/__fragments/__1654290727842_1654290727842_1369fd65d2f743b69a03aa5e20924148_13/d1_var.tdb
-rw-r--r--  1 johnkerl  staff    22M Jun  3 17:08 try-pre-consol/X/data/__fragments/__1654290481080_1654290481080_e21750dd6d554923890ebd7e20b710ba_13/d1_var.tdb
...
...
```

After:

```
-rw-r--r--  1 johnkerl  staff   418M Jun  3 18:34 try2-pre-consol/X/data/__fragments/__1654295520752_1654295520752_6dd3c943b0ca4bcdbc4ad7fc800bda9f_13/d1_var.tdb
-rw-r--r--  1 johnkerl  staff   419M Jun  3 19:18 try2-pre-consol/X/data/__fragments/__1654298102675_1654298102675_7eaa33c6136d40ceb5d73f8bafb7e79d_13/d1_var.tdb
-rw-r--r--  1 johnkerl  staff   420M Jun  3 18:26 try2-pre-consol/X/data/__fragments/__1654295062885_1654295062885_848ffc5c3e1a448aa014cb5e49fb9533_13/d1_var.tdb
-rw-r--r--  1 johnkerl  staff   421M Jun  3 19:04 try2-pre-consol/X/data/__fragments/__1654297254681_1654297254681_c2c947961619430aa844dd3aa6a4bbf4_13/d1_var.tdb
-rw-r--r--  1 johnkerl  staff   424M Jun  3 18:49 try2-pre-consol/X/data/__fragments/__1654296364201_1654296364201_bb175331dfe743b883811374ee794128_13/d1_var.tdb
```

However, this is consuming undesirably much memory at runtime on larger files, in the CSR -> chunk -> COO -> sort -> IJK triples -> tiledb write sequence
https://github.com/single-cell-data/TileDB-SingleCell/blob/main/apis/python/src/tiledbsc/assay_matrix.py#L294-L385


