### PR TITLE
Add len and cell-count convenience accessors

### DIFF
--- a/apis/python/examples/soma-collection-reconnaissance.md
+++ b/apis/python/examples/soma-collection-reconnaissance.md
@@ -23,18 +23,21 @@ import tiledbsc
 soco = tiledbsc.SOMACollection('/mini-corpus/soco')
 
 print("TOTAL CELL COUNT:")
-print(sum(len(soma.obs.ids()) for soma in soco))
+print(soco.cell_count())
 ```
 
 ```
 TOTAL CELL COUNT:
-2439683
+2464363
 ```
 
 ```
 print()
-for soma in soco:
-  print("%-60s %d" % (soma.name, len(soma.obs.ids())))
+print([soma.cell_count() for soma in soco])
+```
+
+```
+[264824, 4636, 6288, 2223, 59506, 100, 2638, 982538, 385, 67794, 2638, 104148, 44721, 3799, 11574, 1679, 3589, 700, 584884, 16245, 4603, 3726, 4636, 7348, 3589, 40268, 12971, 4232, 80, 82478, 97499, 38024]
 ```
 
 ```

--- a/apis/python/src/tiledbsc/soma.py
+++ b/apis/python/src/tiledbsc/soma.py
@@ -174,3 +174,10 @@ class SOMA(TileDBGroup):
         An alias for `soma.var.ids()`.
         """
         return self.var.ids()
+
+    # ----------------------------------------------------------------
+    def cell_count(self) -> int:
+        """
+        Returns the `obs_id` in `soma.obs`.
+        """
+        return len(self.obs.ids())

--- a/apis/python/src/tiledbsc/soma_collection.py
+++ b/apis/python/src/tiledbsc/soma_collection.py
@@ -45,6 +45,13 @@ class SOMACollection(TileDBGroup):
         )
 
     # ----------------------------------------------------------------
+    def __len__(self) -> int:
+        """
+        Implements `len(soco)`. Returns the number of elements in the collection.
+        """
+        return len(self._get_member_names())
+
+    # ----------------------------------------------------------------
     def add(self, soma: SOMA) -> None:
         """
         Adds a `SOMA` to the `SOMACollection`.
@@ -111,3 +118,10 @@ class SOMACollection(TileDBGroup):
                 )
 
             return SOMA(uri=obj.uri, name=name, parent=self)
+
+    # ----------------------------------------------------------------
+    def cell_count(self) -> int:
+        """
+        Returns sum of `soma.cell_count()` over SOMAs in the collection.
+        """
+        return sum(soma.cell_count() for soma in self)


### PR DESCRIPTION
These are keystroke-savers for frequently-asked questions about SOMA/SOCO data.