### PR TITLE
Remove numpy pin

### DIFF
--- a/apis/python/setup.cfg
+++ b/apis/python/setup.cfg
@@ -29,12 +29,9 @@ package_dir=
 packges = tiledbsc
 platforms = any
 zip_safe = False
-# The numpy pin is to avoid
-# "ImportError: Numba needs NumPy 1.21 or less"
 install_requires =
     tiledb>=0.15.2
     scipy
-    numpy<1.22
     pandas
     pyarrow
     anndata


### PR DESCRIPTION
Numba's latest version [0.55.2](https://github.com/numba/numba/releases/tag/0.55.2) added support for numpy 1.22, so we no longer need to pin it to `<1.22`, which was preventing installation on M1 macs. 

Further, because numpy is already a requirement of tiledb-py, we can drop it from `setup.cfg` altogether.