### PR TITLE
Implement Python package versioning [RFC]

### DIFF
--- a/apis/python/pyproject.toml
+++ b/apis/python/pyproject.toml
@@ -6,3 +6,6 @@ requires = [
     "pybind11>=2.6.2"
 ]
 build-backend = "setuptools.build_meta"
+
+[tool.setuptools_scm]
+write_to = "version.py"

--- a/apis/python/pyproject.toml
+++ b/apis/python/pyproject.toml
@@ -6,6 +6,3 @@ requires = [
     "pybind11>=2.6.2"
 ]
 build-backend = "setuptools.build_meta"
-
-# See also src/tiledbsc/__init__.py
-version = "0.1.0"

--- a/apis/python/pyproject.toml
+++ b/apis/python/pyproject.toml
@@ -6,3 +6,6 @@ requires = [
     "pybind11>=2.6.2"
 ]
 build-backend = "setuptools.build_meta"
+
+# See also src/tiledbsc/__init__.py
+version = "0.1.0"

--- a/apis/python/pyproject.toml
+++ b/apis/python/pyproject.toml
@@ -6,6 +6,3 @@ requires = [
     "pybind11>=2.6.2"
 ]
 build-backend = "setuptools.build_meta"
-
-[tool.setuptools_scm]
-write_to = "version.py"

--- a/apis/python/setup.cfg
+++ b/apis/python/setup.cfg
@@ -51,8 +51,3 @@ ci =
     pytest
     anndata
     pybind11
-
-[tool.setuptools_scm]
-version_scheme = guess-next-dev
-local_scheme = dirty-tag
-write_to = ./version.py

--- a/apis/python/setup.py
+++ b/apis/python/setup.py
@@ -1,4 +1,11 @@
 import setuptools
 
 if __name__ == "__main__":
-    setuptools.setup()
+    setuptools.setup(
+        setup_requires=["setuptools_scm"],
+        use_scm_version={
+            "version_scheme": "guess-next-dev",
+            "local_scheme": "dirty-tag",
+            "write_to": "tiledb/ml/version.py",
+        },
+    )

--- a/apis/python/setup.py
+++ b/apis/python/setup.py
@@ -6,6 +6,9 @@ if __name__ == "__main__":
         use_scm_version={
             "version_scheme": "guess-next-dev",
             "local_scheme": "dirty-tag",
-            "write_to": "tiledb/ml/version.py",
+            # This is weird. The write_to requires apis/python/..., as though the "pwd" is two
+            # levels up from here.  Yet the root requires ../.., as though the "pwd" is right here.
+            "write_to": "apis/python/version.py",
+            "root": "../..",
         },
     )

--- a/apis/python/src/tiledbsc/__init__.py
+++ b/apis/python/src/tiledbsc/__init__.py
@@ -1,3 +1,8 @@
+# This reads ../../pyproject.toml
+import importlib.metadata
+
+__version__ = importlib.metadata.version("tiledbsc")
+
 from .soma_collection import SOMACollection
 from .soma import SOMA
 from .soma_options import SOMAOptions

--- a/apis/python/src/tiledbsc/__init__.py
+++ b/apis/python/src/tiledbsc/__init__.py
@@ -1,8 +1,22 @@
-# TODO: probably remove
-# # This reads ../../pyproject.toml
-# import importlib.metadata
-#
-# __version__ = importlib.metadata.version("tiledbsc")
+import setuptools_scm
+
+# __version__ = setuptools_scm.get_version(root='../../../..')
+# Nope:
+# >>> import tiledbsc
+# >>> tiledbsc.__version__
+# LookupError: setuptools-scm was unable to detect version for /Users/johnkerl/git.
+
+# __version__ = setuptools_scm.get_version(root='../../..')
+# >>> import tiledbsc
+# >>> tiledbsc.__version__
+# Nope:
+# LookupError: setuptools-scm was unable to detect version for /Users/johnkerl/git/single-cell-data.
+
+__version__ = setuptools_scm.get_version(root='../..')
+# >>> import tiledbsc
+# >>> tiledbsc.__version__
+# '0.0.2.dev0+g1e1e691.d20220620'
+# BUT this only works when I'm cd'ed into /Users/johnkerl/git/single-cell-data/TileDB-SingleCell/apis/python
 
 from .soma_collection import SOMACollection
 from .soma import SOMA

--- a/apis/python/src/tiledbsc/__init__.py
+++ b/apis/python/src/tiledbsc/__init__.py
@@ -1,4 +1,10 @@
 # ----------------------------------------------------------------
+# How this works:
+# o Have tagged a version in Git
+# o If we are checked out on a tagged version we should get soemthing like '1.2.3'
+# o If we aren't we should get something like '1.2.3.dev9+g73388a'
+# o If the user hasn't obtained this code using Git -- e.g. if they did `pip install` -- I don't
+#   know how this will work.
 import setuptools_scm
 
 # __version__ = setuptools_scm.get_version(root='../../../..')

--- a/apis/python/src/tiledbsc/__init__.py
+++ b/apis/python/src/tiledbsc/__init__.py
@@ -1,3 +1,4 @@
+# ----------------------------------------------------------------
 import setuptools_scm
 
 # __version__ = setuptools_scm.get_version(root='../../../..')
@@ -18,6 +19,7 @@ __version__ = setuptools_scm.get_version(root='../..')
 # '0.0.2.dev0+g1e1e691.d20220620'
 # BUT this only works when I'm cd'ed into /Users/johnkerl/git/single-cell-data/TileDB-SingleCell/apis/python
 
+# ----------------------------------------------------------------
 from .soma_collection import SOMACollection
 from .soma import SOMA
 from .soma_options import SOMAOptions

--- a/apis/python/src/tiledbsc/__init__.py
+++ b/apis/python/src/tiledbsc/__init__.py
@@ -13,13 +13,21 @@ import setuptools_scm
 # Nope:
 # LookupError: setuptools-scm was unable to detect version for /Users/johnkerl/git/single-cell-data.
 
-__version__ = setuptools_scm.get_version(root='../..')
+# __version__ = setuptools_scm.get_version(root='../..')
 # >>> import tiledbsc
 # >>> tiledbsc.__version__
 # '0.0.2.dev0+g1e1e691.d20220620'
 # BUT this only works when I'm cd'ed into /Users/johnkerl/git/single-cell-data/TileDB-SingleCell/apis/python
 
-# ----------------------------------------------------------------
+# __version__ = setuptools_scm.get_version(root="../..", relative_to=__file__)
+# >>> import tiledbsc
+# >>> tiledbsc.__version__
+# Nope:
+# LookupError: setuptools-scm was unable to detect version for /Users/johnkerl/git/single-cell-data/TileDB-SingleCell/apis/python.
+
+__version__ = setuptools_scm.get_version(root="../../../..", relative_to=__file__)
+
+# ================================================================
 from .soma_collection import SOMACollection
 from .soma import SOMA
 from .soma_options import SOMAOptions

--- a/apis/python/src/tiledbsc/__init__.py
+++ b/apis/python/src/tiledbsc/__init__.py
@@ -1,7 +1,8 @@
-# This reads ../../pyproject.toml
-import importlib.metadata
-
-__version__ = importlib.metadata.version("tiledbsc")
+# TODO: probably remove
+# # This reads ../../pyproject.toml
+# import importlib.metadata
+#
+# __version__ = importlib.metadata.version("tiledbsc")
 
 from .soma_collection import SOMACollection
 from .soma import SOMA


### PR DESCRIPTION
# What kind of works

```
$ git clone https://github.com/single-cell-data/TileDB-SingleCell

$ cd TileDB-SingleCell/apis/python

$ pip install -e .

$ python

>>> import tiledbsc

>>> tiledbsc.__version__
0.0.2.dev9+g73388a4
```

I do not know how this will work if the user didn't install via `git clone` and `pip install -e .`.

# What did not work

Note: from [https://pypi.org/project/setuptools-scm/](https://pypi.org/project/setuptools-scm/) I tried

`pyproject.toml`
```
[tool.setuptools_scm]
write_to = "version.py"
```

but `python -m setuptools_scm` gave me

```
Traceback (most recent call last):
  File "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/runpy.py", line 197, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/setuptools_scm-6.4.2-py3.9.egg/setuptools_scm/__main__.py", line 83, in <module>
    main()
  File "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/setuptools_scm-6.4.2-py3.9.egg/setuptools_scm/__main__.py", line 30, in main
    assert version is not None
AssertionError
```

and `version.py` was not written.

I don't know how to make this work in a non-deprecated way (and would love any pointers from anyone who has them) -- what's on this PR at the moment seems to work.

# Another way that did not work

`pyproject.toml`
```
[tool.setuptools_scm]
write_to = "version.py"
root = "../../../.."
relative_to = "__file__"
```

but

```
>>> import tiledbsc
>>> tiledbsc.__version__
AttributeError: module 'tiledbsc' has no attribute '__version__'
```

Also, `version.py` is not created.

# Fourth try

As of commit https://github.com/single-cell-data/TileDB-SingleCell/pull/165/commits/a92d367c5e83e4a2c6a32501193963d5ca21da27: when I did `pip install -e .` within the `apis/python` subdirectory (where this repo has its Python code) I get the following stack trace:

<details>

```
johnkerl@Kerl-MBP[prod][python]$ pip install -e .
Obtaining file:///Users/johnkerl/git/single-cell-data/TileDB-SingleCell/apis/python
  Installing build dependencies ... done
  Checking if build backend supports build_editable ... done
  Getting requirements to build wheel ... done
  Preparing metadata (pyproject.toml) ... error
  error: subprocess-exited-with-error

  × Preparing metadata (pyproject.toml) did not run successfully.
  │ exit code: 1
  ╰─> [36 lines of output]
      Traceback (most recent call last):
        File "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/pip/_vendor/pep517/in_process/_in_process.py", line 363, in <module>
          main()
        File "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/pip/_vendor/pep517/in_process/_in_process.py", line 345, in main
          json_out['return_val'] = hook(**hook_input['kwargs'])
        File "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/pip/_vendor/pep517/in_process/_in_process.py", line 164, in prepare_metadata_for_build_wheel
          return hook(metadata_directory, config_settings)
        File "/private/var/folders/7l/_wsjyk5d4p3dz3kbz7wxn7t00000gn/T/pip-build-env-fk7ew2nv/overlay/lib/python3.9/site-packages/setuptools/build_meta.py", line 188, in prepare_metadata_for_build_wheel
          self.run_setup()
        File "/private/var/folders/7l/_wsjyk5d4p3dz3kbz7wxn7t00000gn/T/pip-build-env-fk7ew2nv/overlay/lib/python3.9/site-packages/setuptools/build_meta.py", line 174, in run_setup
          exec(compile(code, __file__, 'exec'), locals())
        File "setup.py", line 4, in <module>
          setuptools.setup(
        File "/private/var/folders/7l/_wsjyk5d4p3dz3kbz7wxn7t00000gn/T/pip-build-env-fk7ew2nv/overlay/lib/python3.9/site-packages/setuptools/__init__.py", line 87, in setup
          return distutils.core.setup(**attrs)
        File "/private/var/folders/7l/_wsjyk5d4p3dz3kbz7wxn7t00000gn/T/pip-build-env-fk7ew2nv/overlay/lib/python3.9/site-packages/setuptools/_distutils/core.py", line 139, in setup
          _setup_distribution = dist = klass(attrs)
        File "/private/var/folders/7l/_wsjyk5d4p3dz3kbz7wxn7t00000gn/T/pip-build-env-fk7ew2nv/overlay/lib/python3.9/site-packages/setuptools/dist.py", line 477, in __init__
          _Distribution.__init__(
        File "/private/var/folders/7l/_wsjyk5d4p3dz3kbz7wxn7t00000gn/T/pip-build-env-fk7ew2nv/overlay/lib/python3.9/site-packages/setuptools/_distutils/dist.py", line 275, in __init__
          self.finalize_options()
        File "/private/var/folders/7l/_wsjyk5d4p3dz3kbz7wxn7t00000gn/T/pip-build-env-fk7ew2nv/overlay/lib/python3.9/site-packages/setuptools/dist.py", line 901, in finalize_options
          ep(self)
        File "/private/var/folders/7l/_wsjyk5d4p3dz3kbz7wxn7t00000gn/T/pip-build-env-fk7ew2nv/overlay/lib/python3.9/site-packages/setuptools/dist.py", line 922, in _finalize_setup_keywords
          ep.load()(self, ep.name, value)
        File "/private/var/folders/7l/_wsjyk5d4p3dz3kbz7wxn7t00000gn/T/pip-build-env-fk7ew2nv/overlay/lib/python3.9/site-packages/setuptools_scm/integration.py", line 75, in version_keyword
          _assign_version(dist, config)
        File "/private/var/folders/7l/_wsjyk5d4p3dz3kbz7wxn7t00000gn/T/pip-build-env-fk7ew2nv/overlay/lib/python3.9/site-packages/setuptools_scm/integration.py", line 51, in _assign_version
          _version_missing(config)
        File "/private/var/folders/7l/_wsjyk5d4p3dz3kbz7wxn7t00000gn/T/pip-build-env-fk7ew2nv/overlay/lib/python3.9/site-packages/setuptools_scm/__init__.py", line 106, in _version_missing
          raise LookupError(
      LookupError: setuptools-scm was unable to detect version for /Users/johnkerl/git/single-cell-data/TileDB-SingleCell/apis/python.

      Make sure you're either building from a fully intact git repository or PyPI tarballs. Most other sources (such as GitHub's tarballs, a git checkout without the .git folder) don't contain the necessary metadata and will not work.

      For example, if you're using pip, instead of https://github.com/user/proj/archive/master.zip use git+https://github.com/user/proj.git#egg=proj
      [end of output]

  note: This error originates from a subprocess, and is likely not a problem with pip.
error: metadata-generation-failed

× Encountered error while generating package metadata.
╰─> See above for output.

note: This is an issue with the package mentioned above, not pip.
hint: See above for details.
WARNING: There was an error checking the latest version of pip.
```

</details>