### PR TITLE
Depend on TileDB-Py 0.15.5

### DIFF
--- a/apis/python/setup.cfg
+++ b/apis/python/setup.cfg
@@ -30,7 +30,7 @@ packges = tiledbsc
 platforms = any
 zip_safe = False
 install_requires =
-    tiledb>=0.15.2
+    tiledb>=0.15.5
     scipy
     pandas
     pyarrow


### PR DESCRIPTION
Fixes intermittent SEGV as reported by @bkmartinjr, which happened when creating a `SOMACollection` then a `SOMA` within it, using the same tiledb-context object.

Does not address `bool` issue, as [0.15.5](https://github.com/TileDB-Inc/TileDB-Py/releases/tag/0.15.5) doesn't do what we need to get `bool` support in `tiledb.from_pandas` context (`AnnotationDataFrame` as used by `obs` and `var`), since `TileDB-Py` 0.15.5 depends on core 2.9.4:
https://github.com/TileDB-Inc/TileDB-Py/blob/dev/tiledb/dataframe_.py#L125-L127