### PR TITLE
triples_to_dense_df utility method

### DIFF
--- a/apis/python/doc/util.md
+++ b/apis/python/doc/util.md
@@ -57,6 +57,19 @@ conversion to anndata, we need make a sparse COO/IJV-format array where the indi
 not strings but ints, matching the obs and var labels.
 The `return_as` parameter must be one of `"csr"` or `"csc"`.
 
+<a id="tiledbsc.util.triples_to_dense_df"></a>
+
+#### triples\_to\_dense\_df
+
+```python
+def triples_to_dense_df(sparse_df: pd.DataFrame, fillna=0.0) -> pd.DataFrame
+```
+
+Output from X dataframe reads is in "triples" format, e.g. two index columns `obs_id` and `var_id`,
+and data column `value`. This is the default format, and is appropriate for large, possibly sparse matrices.
+However, sometimes we want a dense matrix with `obs_id` row labels, `var_id` column labels, and `value` data.
+This function produces that.
+
 <a id="tiledbsc.util.ETATracker"></a>
 
 ## ETATracker Objects

--- a/apis/python/src/tiledbsc/util.py
+++ b/apis/python/src/tiledbsc/util.py
@@ -337,6 +337,30 @@ def X_and_ids_to_sparse_matrix(
         )
 
 
+# ----------------------------------------------------------------
+def triples_to_dense_df(sparse_df: pd.DataFrame, fillna=0.0) -> pd.DataFrame:
+    """
+    Output from X dataframe reads is in "triples" format, e.g. two index columns `obs_id` and `var_id`,
+    and data column `value`. This is the default format, and is appropriate for large, possibly sparse matrices.
+    However, sometimes we want a dense matrix with `obs_id` row labels, `var_id` column labels, and `value` data.
+    This function produces that.
+    """
+    assert isinstance(sparse_df, pd.DataFrame)
+    attr_name = sparse_df.keys()[0]
+
+    index_names = sparse_df.index.names
+    assert len(index_names) == 2
+    row_index_name = index_names[0]
+    col_index_name = index_names[1]
+
+    # Make the index columns accessible as data columns.
+    sparse_df = sparse_df.reset_index()
+
+    return sparse_df.pivot(
+        index=row_index_name, columns=col_index_name, values=attr_name
+    ).fillna(fillna)
+
+
 # ================================================================
 class ETATracker:
     """


### PR DESCRIPTION
Queries of sparse arrays using the `tiledb` Python API return triples of `obs_id`, `var_id`, `value`.

Sometimes for documentation/exploration purposes we want to see these densified.

This is used for an example on #173.

Example:

```
>>> soma.X.data.df()
                            value
obs_id         var_id
AAATTCGAATCACG AKR1C3   -0.325888
               CA2      -0.346938
               CD1C     -0.253005
               GNLY     -0.528670
               HLA-DPB1 -1.039994
...                           ...
TTTAGCTGTACTCT S100A9    1.112879
               SDPR     -0.388176
               TREML1   -0.328625
               TUBB1    -0.350375
               VDAC3    -0.524551

[1600 rows x 1 columns]

>>> tiledbsc.util.triples_to_dense_df(soma.X.data.df())
var_id            AKR1C3       CA2      CD1C      GNLY  HLA-DPB1  ...    S100A9      SDPR    TREML1     TUBB1     VDAC3
obs_id                                                            ...
AAATTCGAATCACG -0.325888 -0.346938 -0.253005 -0.528670 -1.039994  ...  1.820099 -0.388176 -0.328625 -0.350375 -0.524551
AAGCAAGAGCTTAG -0.325888 -0.346938 -0.253005  1.775332 -1.039994  ... -0.763966 -0.388176 -0.328625 -0.350375 -0.524551
AAGCGACTTTGACG -0.325888 -0.346938 -0.253005 -0.528670  0.412720  ...  1.127458 -0.388176 -0.328625 -0.350375 -0.524551
AATGCGTGGACGGA -0.325888 -0.346938 -0.253005 -0.528670  0.867139  ...  1.357089 -0.388176 -0.328625 -0.350375 -0.524551
AATGTTGACAGTCA -0.325888 -0.346938 -0.253005 -0.528670 -1.039994  ... -0.763966 -0.388176 -0.328625 -0.350375  1.862666
...                  ...       ...       ...       ...       ...  ...       ...       ...       ...       ...       ...
TTACGTACGTTCAG -0.325888  2.779452 -0.253005 -0.528670 -1.039994  ... -0.763966  2.642233  3.055359  3.310155  1.795607
TTGAGGACTACGCA -0.325888 -0.346938  3.494552 -0.528670  1.421647  ... -0.763966 -0.388176 -0.328625 -0.350375  0.829568
TTGCATTGAGCTAC -0.325888 -0.346938 -0.253005 -0.528670  0.767907  ... -0.763966 -0.388176 -0.328625 -0.350375 -0.524551
TTGGTACTGAATCC -0.325888 -0.346938 -0.253005 -0.528670 -1.039994  ... -0.763966 -0.388176 -0.328625 -0.350375 -0.524551
TTTAGCTGTACTCT -0.325888 -0.346938 -0.253005 -0.528670  1.122055  ...  1.112879 -0.388176 -0.328625 -0.350375 -0.524551

[80 rows x 20 columns]
```