### PR TITLE
Github action for uploading to PyPI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,11 @@
 name: TileDB-SingleCell CI
 
-on: [push, pull_request]
+on:
+  pull_request:
+  push:
+    branches: [main]
+  release:
+    types: [published]
 
 jobs:
   build:
@@ -41,12 +46,31 @@ jobs:
         python-version: ${{ matrix.python-version }}
 
     - name: Install Python packages
-      run: |
-        python -m pip install apis/python[ci]
+      run: python -m pip install apis/python[ci]
 
     - name: Run pytests
-      run: |
-        python -m pytest apis/python/tests
+      run: python -m pytest apis/python/tests
+
+    - name: Build wheel distribution
+      run: python -m pip wheel --no-deps --wheel-dir=dist apis/python
+
+    - name: Publish package to TestPyPI
+      if: matrix.os == 'ubuntu-latest' && github.event_name == 'release'
+      uses: pypa/gh-action-pypi-publish@master
+      continue-on-error: true
+      with:
+        repository_url: https://test.pypi.org/legacy/
+        user: __token__
+        password: ${{ secrets.TEST_PYPI_TOKEN }}
+        verbose: true
+
+    - name: Publish package to PyPI
+      if: matrix.os == 'ubuntu-latest' && github.event_name == 'release' && !github.event.release.prerelease
+      uses: pypa/gh-action-pypi-publish@master
+      with:
+        user: __token__
+        password: ${{ secrets.PYPI_TOKEN }}
+        verbose: true
 
     - name: Build libtiledbsc
       shell: pwsh


### PR DESCRIPTION
Update the CI Github actions to:
- Build a wheel for the TileDB-SingleCell Python API
- When a new release is published:
  - Upload it to [Test PyPI](https://test.pypi.org/)
  - Upload it to (the official) PyPI If it's not a pre-release.

An admin of this repo must:
1. Create an account on Test PyPI and PyPI to register this project under.
   Note: these are two independent accounts. 
2. Create an API token for each account (under account settings: https://test.pypi.org/manage/account/ / https://pypi.org/manage/account/) to use for this project.
3. Add two [action secrets](https://github.com/single-cell-data/TileDB-SingleCell/settings/secrets/actions) in the settings of this repo:
   - `TEST_PYPI_TOKEN`: API token for Test PyPI
   - `PYPI_TOKEN`: API token for PyPI
