### PR TITLE
Expressive cell-count queries

### DIFF
--- a/apis/python/doc/annotation_dataframe.md
+++ b/apis/python/doc/annotation_dataframe.md
@@ -44,6 +44,16 @@ def ids() -> List[str]
 
 Returns the `obs_ids` in the matrix (for `obs`) or the `var_ids` (for `var`).
 
+<a id="tiledbsc.annotation_dataframe.AnnotationDataFrame.__len__"></a>
+
+#### \_\_len\_\_
+
+```python
+def __len__() -> int
+```
+
+Implements `len(soma.obs)` and `len(soma.var)`.
+
 <a id="tiledbsc.annotation_dataframe.AnnotationDataFrame.keys"></a>
 
 #### keys

--- a/apis/python/doc/soma.md
+++ b/apis/python/doc/soma.md
@@ -91,16 +91,6 @@ def var_keys() -> List[str]
 
 An alias for `soma.var.ids()`.
 
-<a id="tiledbsc.soma.SOMA.cell_count"></a>
-
-#### cell\_count
-
-```python
-def cell_count() -> int
-```
-
-Returns the `obs_id` in `soma.obs`.
-
 <a id="tiledbsc.soma.SOMA.get_obs_value_counts"></a>
 
 #### get\_obs\_value\_counts

--- a/apis/python/doc/soma_collection.md
+++ b/apis/python/doc/soma_collection.md
@@ -104,16 +104,6 @@ def __getitem__(name) -> SOMA
 Returns a `SOMA` element at the given name within the group, or `None` if no such
 member exists.  Overloads the `[...]` operator.
 
-<a id="tiledbsc.soma_collection.SOMACollection.cell_count"></a>
-
-#### cell\_count
-
-```python
-def cell_count() -> int
-```
-
-Returns sum of `soma.cell_count()` over SOMAs in the collection.
-
 <a id="tiledbsc.soma_collection.SOMACollection.query"></a>
 
 #### query

--- a/apis/python/examples/soco-reconnaissance.md
+++ b/apis/python/examples/soco-reconnaissance.md
@@ -19,57 +19,51 @@ This collection includes data on about 2.4 million cells:
 
 ```
 import tiledbsc
-
 soco = tiledbsc.SOMACollection('/mini-corpus/soco')
 
-print("TOTAL CELL COUNT:")
-print(soco.cell_count())
-```
-
-```
-TOTAL CELL COUNT:
+>>> sum(len(soma.obs) for soma in soco)
 2464363
-```
 
-```
-print()
-print([soma.cell_count() for soma in soco])
-```
-
-```
+>>> [len(soma.obs) for soma in soco]
 [264824, 4636, 6288, 2223, 59506, 100, 2638, 982538, 385, 67794, 2638, 104148, 44721, 3799, 11574, 1679, 3589, 700, 584884, 16245, 4603, 3726, 4636, 7348, 3589, 40268, 12971, 4232, 80, 82478, 97499, 38024]
 ```
 
 ```
-tabula-sapiens-stromal                                       82478
-Puck_200903_10                                               38024
-autoimmunity-pbmcs                                           97499
-pbmc-small                                                   80
-vieira19_Alveoli_and_parenchyma_anonymised.processed         12971
-af9d8c03-696c-4997-bde8-8ef00844881b                         4232
-d4db74ad-a129-4b1a-b9da-1b30db86bbe4-issue-74                3589
-single-cell-transcriptomes                                   40268
-local2                                                       7348
-human-kidney-tumors-wilms                                    4636
-0cfab2d4-1b79-444e-8cbe-2ca9671ca85e                         3726
-issue-74                                                     3589
-10x_pbmc68k_reduced                                          700
-integrated-human-lung-cell-atlas                             584884
-4056cbab-2a32-4c9e-a55f-c930bc793fb6                         4603
-adult-mouse-cortical-cell-taxonomy                           1679
-tabula-sapiens-epithelial                                    104148
-Single_cell_atlas_of_peripheral_immune_response_to_SARS_CoV_2_infection 44721
-longitudinal-profiling-49                                    11574
-azimuth-meta-analysis                                        982538
-developmental-single-cell-atlas-of-the-murine-lung           67794
-local3                                                       385
-pbmc3k-krilow                                                2638
-pbmc3k_processed                                             2638
-subset_100_100                                               100
-tabula-sapiens-immune                                        264824
-brown-adipose-tissue-mouse                                   2223
-acute-covid19-cohort                                         59506
-issue-69                                                     6288
+>>> for soma in soco:
+...     print(len(soma.obs), soma.name)
+...
+264824 tabula-sapiens-immune
+4636 wilms-tumors-seurat
+6288 issue-69
+2223 brown-adipose-tissue-mouse
+59506 acute-covid19-cohort
+100 subset_100_100
+2638 pbmc3k_processed
+982538 azimuth-meta-analysis
+385 local3
+67794 developmental-single-cell-atlas-of-the-murine-lung
+2638 pbmc3k-krilow
+104148 tabula-sapiens-epithelial
+44721 Single_cell_atlas_of_peripheral_immune_response_to_SARS_CoV_2_infection
+3799 adipocytes-seurat
+11574 longitudinal-profiling-49
+1679 adult-mouse-cortical-cell-taxonomy
+3589 issue-74
+700 10x_pbmc68k_reduced
+584884 integrated-human-lung-cell-atlas
+16245 issue-71
+4603 4056cbab-2a32-4c9e-a55f-c930bc793fb6
+3726 0cfab2d4-1b79-444e-8cbe-2ca9671ca85e
+4636 human-kidney-tumors-wilms
+7348 local2
+3589 d4db74ad-a129-4b1a-b9da-1b30db86bbe4-issue-74
+40268 single-cell-transcriptomes
+12971 vieira19_Alveoli_and_parenchyma_anonymised.processed
+4232 af9d8c03-696c-4997-bde8-8ef00844881b
+80 pbmc-small
+82478 tabula-sapiens-stromal
+97499 autoimmunity-pbmcs
+38024 Puck_200903_10
 ```
 
 ## Cell-counts before running a query

--- a/apis/python/examples/soco-reconnaissance.md
+++ b/apis/python/examples/soco-reconnaissance.md
@@ -3,7 +3,7 @@ Next, let's do some cross-cutting queries over schemas of all SOMAs in the colle
 in those columns, are most likely to be promising in terms of yielding results given our
 mini-corpus.
 
-## Cell-counts
+## Total cell-counts
 
 The mini-corpus we prepared is 29 SOMAs, 26GB total:
 
@@ -70,6 +70,26 @@ tabula-sapiens-immune                                        264824
 brown-adipose-tissue-mouse                                   2223
 acute-covid19-cohort                                         59506
 issue-69                                                     6288
+```
+
+## Cell-counts before running a query
+
+Before running a query, we may wish to know how many cells will be involved in the result:
+
+```
+>>> [soma.obs.query('cell_type == "B cell"').size for soma in soco if 'cell_type' in soma.obs.keys()]
+[514982, 0, 0, 14283, 245240, 391446, 0, 0, 0, 125154, 0, 29060, 0, 0, 311259, 176, 6120, 2480, 0, 0, 0, 26325, 5220, 0, 12750, 0]
+
+>>> sum([soma.obs.query('cell_type == "B cell"').size for soma in soco if 'cell_type' in soma.obs.keys()])
+1684495
+```
+
+```
+>>> [soma.obs.query('cell_type == "leukocyte"').size for soma in soco if 'cell_type' in soma.obs.keys()]
+[59436, 5616, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 5472, 0, 0, 0, 0, 0, 0, 3753]
+
+>>> sum([soma.obs.query('cell_type == "leukocyte"').size for soma in soco if 'cell_type' in soma.obs.keys()])
+74277
 ```
 
 ## Datasets having all three of obs.cell_type, obs.tissue, and obs.feature_name

--- a/apis/python/src/tiledbsc/annotation_dataframe.py
+++ b/apis/python/src/tiledbsc/annotation_dataframe.py
@@ -78,6 +78,13 @@ class AnnotationDataFrame(TileDBArray):
             return [e.decode() for e in retval]
 
     # ----------------------------------------------------------------
+    def __len__(self) -> int:
+        """
+        Implements `len(soma.obs)` and `len(soma.var)`.
+        """
+        return len(self.ids())
+
+    # ----------------------------------------------------------------
     def keys(self) -> List[str]:
         """
         Returns the column names for the `obs` or `var` dataframe.  For obs and varp, `.keys()` is a

--- a/apis/python/src/tiledbsc/annotation_dataframe.py
+++ b/apis/python/src/tiledbsc/annotation_dataframe.py
@@ -158,13 +158,9 @@ class AnnotationDataFrame(TileDBArray):
                     slice_df = slice_query.df[:]
                 else:
                     slice_df = slice_query.df[ids]
-            nobs = len(slice_df)
-            if nobs == 0:
-                return None
-            else:
-                # This is the 'decode on read' part of our logic; in dim_select we have the 'encode on write' part.
-                # Context: https://github.com/single-cell-data/TileDB-SingleCell/issues/99.
-                return self._ascii_to_unicode_dataframe_readback(slice_df)
+            # This is the 'decode on read' part of our logic; in dim_select we have the 'encode on write' part.
+            # Context: https://github.com/single-cell-data/TileDB-SingleCell/issues/99.
+            return self._ascii_to_unicode_dataframe_readback(slice_df)
 
     # ----------------------------------------------------------------
     def _ascii_to_unicode_dataframe_readback(self, df) -> pd.DataFrame:

--- a/apis/python/src/tiledbsc/soma.py
+++ b/apis/python/src/tiledbsc/soma.py
@@ -172,13 +172,6 @@ class SOMA(TileDBGroup):
         return self.var.ids()
 
     # ----------------------------------------------------------------
-    def cell_count(self) -> int:
-        """
-        Returns the `obs_id` in `soma.obs`.
-        """
-        return len(self.obs.ids())
-
-    # ----------------------------------------------------------------
     def get_obs_value_counts(self, obs_label: str) -> pd.DataFrame:
         """
         Given an obs label, e.g. `cell_type`, returns a dataframe count the number of different

--- a/apis/python/src/tiledbsc/soma_collection.py
+++ b/apis/python/src/tiledbsc/soma_collection.py
@@ -125,13 +125,6 @@ class SOMACollection(TileDBGroup):
             return SOMA(uri=obj.uri, name=name, parent=self)
 
     # ----------------------------------------------------------------
-    def cell_count(self) -> int:
-        """
-        Returns sum of `soma.cell_count()` over SOMAs in the collection.
-        """
-        return sum(soma.cell_count() for soma in self)
-
-    # ----------------------------------------------------------------
     def query(
         self,
         obs_attr_names: Optional[List[str]] = None,

--- a/apis/python/tests/test_or-query.py
+++ b/apis/python/tests/test_or-query.py
@@ -38,6 +38,8 @@ def test_or_query(adata):
     assert (
         soma.obs.query('groups == "g1" or groups == "g2"', attrs=["groups"]).size == 80
     )
-    assert soma.obs.query('groups == "g1" and groups == "g2"', attrs=["groups"]) is None
+    assert (
+        soma.obs.query('groups == "g1" and groups == "g2"', attrs=["groups"]).size == 0
+    )
 
     tempdir.cleanup()


### PR DESCRIPTION
These let people easily find cell-count that will be involved before running a query. For example:

```
import tiledbsc
soco = tiledbsc.SOMACollection('/mini-corpus/soco')

>>> [len(soma.obs) for soma in soco]
[264824, 4636, 6288, 2223, 59506, 100, 2638, 982538, 385, 67794, 2638, 104148, 44721, 3799, 11574, 1679, 3589, 700, 584884, 16245, 4603, 3726, 4636, 7348, 3589, 40268, 12971, 4232, 80, 82478, 97499, 38024]

>>> sum(len(soma.obs) for soma in soco)
2464363
```

```
>>> [soma.obs.query('cell_type == "B cell"').size for soma in soco if 'cell_type' in soma.obs.keys()]
[514982, 0, 0, 14283, 245240, 391446, 0, 0, 0, 125154, 0, 29060, 0, 0, 311259, 176, 6120, 2480, 0, 0, 0, 26325, 5220, 0, 12750, 0]

>>> sum([soma.obs.query('cell_type == "B cell"').size for soma in soco if 'cell_type' in soma.obs.keys()])
1684495
```

```
>>> [soma.obs.query('cell_type == "leukocyte"').size for soma in soco if 'cell_type' in soma.obs.keys()]
[59436, 5616, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 5472, 0, 0, 0, 0, 0, 0, 3753]

>>> sum([soma.obs.query('cell_type == "leukocyte"').size for soma in soco if 'cell_type' in soma.obs.keys()])
74277
```
