### PR TITLE
More flake8 findings

### DIFF
--- a/apis/python/tools/desc-ann
+++ b/apis/python/tools/desc-ann
@@ -13,7 +13,6 @@
 # ================================================================
 
 import argparse
-import sys
 
 import tiledbsc
 import tiledbsc.io

--- a/apis/python/tools/desc-soma
+++ b/apis/python/tools/desc-soma
@@ -6,11 +6,9 @@
 # by also revealing array schema.
 # ================================================================
 
-import os
 import sys
 
 import tiledbsc
-import tiledbsc.io
 
 
 def main():

--- a/apis/python/tools/ingestor
+++ b/apis/python/tools/ingestor
@@ -50,12 +50,14 @@ def main():
         default="./tiledb-data",
     )
     parser.add_argument(
-        "--soco", help="Write the SOMA and also append to a SOMACollection there", action="store_true"
+        "--soco",
+        help="Write the SOMA and also append to a SOMACollection there",
+        action="store_true",
     )
     parser.add_argument(
-        "-r", "--relative",
-        help=
-"""
+        "-r",
+        "--relative",
+        help="""
 * If `false` then the group will remember the absolute paths of each member array/subgroup. For
 ingesting to TileDB Cloud, this is necessary.
 
@@ -96,11 +98,11 @@ select `relative=True`. (This is the default.)
     write_soco = args.soco
     verbose = not args.quiet
 
-    if args.relative == 'true':
+    if args.relative == "true":
         soma_options.relative_membership = True
-    elif args.relative == 'false':
+    elif args.relative == "false":
         soma_options.relative_membership = False
-    elif args.relative == 'auto':
+    elif args.relative == "auto":
         soma_options.relative_membership = None
     # No else -- we only allowed those three choices in the argument-parser.
 
@@ -115,23 +117,55 @@ select `relative=True`. (This is the default.)
             output_path = os.path.join(
                 outdir, os.path.splitext(os.path.basename(input_path))[0]
             )
-            ingest_one(input_path, output_path, args.ifexists[0], soma_options, write_soco, outdir, verbose)
+            ingest_one(
+                input_path,
+                output_path,
+                args.ifexists[0],
+                soma_options,
+                write_soco,
+                outdir,
+                verbose,
+            )
     else:
         if len(args.paths) == 0:
             input_path = "anndata/pbmc-small.h5ad"
             output_path = os.path.join(outdir, "pbmc-small")
-            ingest_one(input_path, output_path, args.ifexists[0], soma_options, write_soco, outdir, verbose)
+            ingest_one(
+                input_path,
+                output_path,
+                args.ifexists[0],
+                soma_options,
+                write_soco,
+                outdir,
+                verbose,
+            )
         elif len(args.paths) == 1:
             input_path = args.paths[0]
             # Example 'anndata/pbmc3k_processed.h5ad' -> 'tiledb-data/pbmc3k_processed'
             output_path = os.path.join(
                 outdir, os.path.splitext(os.path.basename(input_path))[0]
             )
-            ingest_one(input_path, output_path, args.ifexists[0], soma_options, write_soco, outdir, verbose)
+            ingest_one(
+                input_path,
+                output_path,
+                args.ifexists[0],
+                soma_options,
+                write_soco,
+                outdir,
+                verbose,
+            )
         elif len(args.paths) == 2:
             input_path = args.paths[0]
             output_path = args.paths[1]
-            ingest_one(input_path, output_path, args.ifexists[0], soma_options, write_soco, outdir, verbose)
+            ingest_one(
+                input_path,
+                output_path,
+                args.ifexists[0],
+                soma_options,
+                write_soco,
+                outdir,
+                verbose,
+            )
         else:
             parser.print_help(file=sys.stderr)
             sys.exit(1)
@@ -180,8 +214,12 @@ def ingest_one(
                 print(f"Already exists; aborting: {output_path}")
                 sys.exit(1)
             elif ifexists == "replace":
-                if output_path.startswith('s3://') or output_path.startswith('tiledb://'):
-                    raise("--ifexists replace currently only is compatible with local-disk paths")
+                if output_path.startswith("s3://") or output_path.startswith(
+                    "tiledb://"
+                ):
+                    raise (
+                        "--ifexists replace currently only is compatible with local-disk paths"
+                    )
                 print(f"Already exists; replacing: {output_path}")
                 shutil.rmtree(output_path)  # Overwrite
             else:
@@ -195,7 +233,9 @@ def ingest_one(
         print(f"Wrote {output_path}")
 
     if write_soco:
-        soco = tiledbsc.SOMACollection(soco_dir, soma_options=soma_options, verbose=verbose)
+        soco = tiledbsc.SOMACollection(
+            soco_dir, soma_options=soma_options, verbose=verbose
+        )
         soco.create_unless_exists()
         if not soco.exists():
             raise Exception(f"Could not create SOCO at {soco.uri}")

--- a/apis/python/tools/outgestor
+++ b/apis/python/tools/outgestor
@@ -15,13 +15,8 @@
 
 import argparse
 import os
-import shutil
 import sys
 
-import anndata as ad
-import numpy as np
-import pandas as pd
-import scipy
 import tiledb
 
 import tiledbsc

--- a/apis/python/tools/peek-ann
+++ b/apis/python/tools/peek-ann
@@ -31,8 +31,10 @@ else:
 
 ann = anndata.read_h5ad(input_path)
 
+
 def decat(ann):
     return tiledbsc.util_ann._decategoricalize(ann)
+
 
 # Interact at the prompt now:
 # * ann.X

--- a/apis/python/tools/peek-soma
+++ b/apis/python/tools/peek-soma
@@ -6,7 +6,6 @@
 #
 # -- then you can inspect the soma object.
 
-import os
 import sys
 import time
 

--- a/apis/python/tools/populate-soco
+++ b/apis/python/tools/populate-soco
@@ -26,13 +26,22 @@ def main():
         default="./soma-collection",
     )
     parser.add_argument(
-        "-a", "--add", help="Add specified SOMA URI(s) to the collection", action="store_true"
+        "-a",
+        "--add",
+        help="Add specified SOMA URI(s) to the collection",
+        action="store_true",
     )
     parser.add_argument(
-        "-r", "--remove", help="Remove specified SOMA URI(s) from the collection", action="store_true"
+        "-r",
+        "--remove",
+        help="Remove specified SOMA URI(s) from the collection",
+        action="store_true",
     )
     parser.add_argument(
-        "-l", "--list", help="List the SOMA URI(s) in the collection", action="store_true"
+        "-l",
+        "--list",
+        help="List the SOMA URI(s) in the collection",
+        action="store_true",
     )
     parser.add_argument(
         "paths", type=str, help="Paths to one or more SOMA directories.", nargs="*"
@@ -44,9 +53,12 @@ def main():
     soco = tiledbsc.SOMACollection(collection_path)
 
     count = 0
-    if args.add: count += 1
-    if args.remove: count += 1
-    if args.list: count += 1
+    if args.add:
+        count += 1
+    if args.remove:
+        count += 1
+    if args.list:
+        count += 1
     if count != 1:
         print(f"{os.path.basename(sys.argv[0])}: need just one of -a, -r, or -l.")
         sys.exit(1)
@@ -62,7 +74,7 @@ def main():
 
     if args.add:
         for soma_uri in args.paths:
-            soma_uri = soma_uri.rstrip('/')
+            soma_uri = soma_uri.rstrip("/")
             name = os.path.basename(soma_uri)
             soma = tiledbsc.SOMA(uri=soma_uri, name=name, parent=soco)
             print(f"Adding {name} to {soma_uri}")
@@ -70,7 +82,7 @@ def main():
 
     if args.remove:
         for soma_uri in args.paths:
-            soma_uri = soma_uri.rstrip('/')
+            soma_uri = soma_uri.rstrip("/")
             name = os.path.basename(soma_uri)
             soma = tiledbsc.SOMA(uri=soma_uri, name=name, parent=soco)
             print(f"Removing {name} from {soma_uri}")


### PR DESCRIPTION
As of #185 we have `isort .` and `flake8` in addition to the already existing `black .`.

However these check only `.py` files; some items in `apis/python/tools` can be checked using `flake8 tools/*`.

Note: The `tools/peek-*` scripts have a `python -i` shebang line and are intended to be invoked and interacted with. This means they _intentionally_ import more packages than the files themselves use; in fact their _entire purpose_ is for keystroke-reduction for the user, so they can get a Python prompt and do things with a minimum of manual imports.