### PR TITLE
tiledb-cloud testing results

### DIFF
--- a/apis/python/doc/annotation_matrix.md
+++ b/apis/python/doc/annotation_matrix.md
@@ -61,18 +61,6 @@ def df(ids=None) -> pd.DataFrame
 Keystroke-saving alias for `.dim_select()`. If `ids` are provided, they're used
 to subselect; if not, the entire dataframe is returned.
 
-<a id="tiledbsc.annotation_matrix.AnnotationMatrix.shape"></a>
-
-#### shape
-
-```python
-def shape() -> Tuple[int, int]
-```
-
-Returns a tuple with the number of rows and number of columns of the `AnnotationMatrix`.
-The row-count is the number of obs_ids (for `obsm` elements) or the number of var_ids (for
-`varm` elements).  The column-count is the number of columns/attributes in the dataframe.
-
 <a id="tiledbsc.annotation_matrix.AnnotationMatrix.from_matrix_and_dim_values"></a>
 
 #### from\_matrix\_and\_dim\_values

--- a/apis/python/doc/soma_collection.md
+++ b/apis/python/doc/soma_collection.md
@@ -26,7 +26,9 @@ def __init__(uri: str,
              parent: Optional[TileDBGroup] = None)
 ```
 
-Create a new `SOMACollection` object. The existing group is opened at the specified `uri` if one is present, otherwise a new group will be created upon ingest.
+Create a new `SOMACollection` object. The existing group is opened at the
+
+specified `uri` if one is present, otherwise a new group will be created upon ingest.
 
 **Arguments**:
 
@@ -119,10 +121,10 @@ Returns sum of `soma.cell_count()` over SOMAs in the collection.
 #### query
 
 ```python
-def query(obs_attr_names: List[str] = [],
+def query(obs_attr_names: Optional[List[str]] = None,
           obs_query_string: str = None,
           obs_ids: List[str] = None,
-          var_attr_names: List[str] = [],
+          var_attr_names: Optional[List[str]] = None,
           var_query_string: str = None,
           var_ids: List[str] = None) -> Optional[SOMASlice]
 ```

--- a/apis/python/doc/util_tiledb.md
+++ b/apis/python/doc/util_tiledb.md
@@ -2,12 +2,12 @@
 
 # tiledbsc.util\_tiledb
 
-<a id="tiledbsc.util_tiledb.show_single_cell_group"></a>
+<a id="tiledbsc.util_tiledb.show_soma_schemas"></a>
 
 #### show\_single\_cell\_group
 
 ```python
-def show_single_cell_group(soma_uri: str,
+def show_soma_schemas(soma_uri: str,
                            ctx: Optional[tiledb.Ctx] = None) -> None
 ```
 

--- a/apis/python/doc/util_tiledb.md
+++ b/apis/python/doc/util_tiledb.md
@@ -4,11 +4,10 @@
 
 <a id="tiledbsc.util_tiledb.show_soma_schemas"></a>
 
-#### show\_single\_cell\_group
+#### show\_soma\_schemas
 
 ```python
-def show_soma_schemas(soma_uri: str,
-                           ctx: Optional[tiledb.Ctx] = None) -> None
+def show_soma_schemas(soma_uri: str, ctx: Optional[tiledb.Ctx] = None) -> None
 ```
 
 Show some summary information about an ingested TileDB Single-Cell Group.  This tool goes a bit beyond `print(tiledb.group.Group(soma_uri))` by also revealing array schema. Additionally, by employing encoded domain-specific knowleldge, it traverses items in the familiar order `X`, `obs`, `var`, etc. rather than using the general-purpose tiledb-group-display function.

--- a/apis/python/src/tiledbsc/__init__.py
+++ b/apis/python/src/tiledbsc/__init__.py
@@ -47,4 +47,4 @@ from .tiledb_object import TileDBObject
 from .uns_array import UnsArray
 from .uns_group import UnsGroup
 from .util_ann import describe_ann_file
-from .util_tiledb import show_single_cell_group
+from .util_tiledb import show_soma_schemas

--- a/apis/python/src/tiledbsc/annotation_matrix_group.py
+++ b/apis/python/src/tiledbsc/annotation_matrix_group.py
@@ -83,7 +83,9 @@ class AnnotationMatrixGroup(TileDBGroup):
 
         for matrix_name in annotation_matrices.keys():
             anndata_matrix = annotation_matrices[matrix_name]
-            matrix_uri = os.path.join(self.uri, matrix_name)
+            matrix_uri = self._get_child_uri(
+                matrix_name
+            )  # See comments in that function
             annotation_matrix = AnnotationMatrix(
                 uri=matrix_uri,
                 name=matrix_name,

--- a/apis/python/src/tiledbsc/annotation_pairwise_matrix_group.py
+++ b/apis/python/src/tiledbsc/annotation_pairwise_matrix_group.py
@@ -103,7 +103,9 @@ class AnnotationPairwiseMatrixGroup(TileDBGroup):
         self.create_unless_exists()
         for matrix_name in annotation_pairwise_matrices.keys():
             anndata_matrix = annotation_pairwise_matrices[matrix_name]
-            matrix_uri = os.path.join(self.uri, matrix_name)
+            matrix_uri = self._get_child_uri(
+                matrix_name
+            )  # See comments in that function
             annotation_pairwise_matrix = AssayMatrix(
                 uri=matrix_uri,
                 name=matrix_name,

--- a/apis/python/src/tiledbsc/assay_matrix_group.py
+++ b/apis/python/src/tiledbsc/assay_matrix_group.py
@@ -1,4 +1,3 @@
-import os
 from typing import List, Optional
 
 import tiledb
@@ -154,7 +153,9 @@ class AssayMatrixGroup(TileDBGroup):
             # Must be done first, to create the parent directory
             self.create_unless_exists()
 
-            assay_matrix_uri = os.path.join(self.uri, layer_name)
+            assay_matrix_uri = self._get_child_uri(
+                layer_name
+            )  # See comments in that function
             assay_matrix = AssayMatrix(
                 uri=assay_matrix_uri,
                 name=layer_name,

--- a/apis/python/src/tiledbsc/raw_group.py
+++ b/apis/python/src/tiledbsc/raw_group.py
@@ -1,4 +1,3 @@
-import os
 from typing import Optional
 
 import anndata as ad
@@ -37,10 +36,10 @@ class RawGroup(TileDBGroup):
         super().__init__(uri=uri, name=name, parent=parent)
         self.parent_obs = obs
 
-        X_uri = os.path.join(self.uri, "X")
-        var_uri = os.path.join(self.uri, "var")
-        varm_uri = os.path.join(self.uri, "varm")
-        varp_uri = os.path.join(self.uri, "varp")
+        X_uri = self._get_child_uri("X")  # See comments in that function
+        var_uri = self._get_child_uri("var")
+        varm_uri = self._get_child_uri("varm")
+        varp_uri = self._get_child_uri("varp")
 
         self.var = AnnotationDataFrame(uri=var_uri, name="var", parent=self)
         self.X = AssayMatrixGroup(

--- a/apis/python/src/tiledbsc/soma.py
+++ b/apis/python/src/tiledbsc/soma.py
@@ -83,15 +83,15 @@ class SOMA(TileDBGroup):
             ctx=ctx,
         )
 
-        obs_uri = os.path.join(self.uri, "obs")
-        var_uri = os.path.join(self.uri, "var")
-        X_uri = os.path.join(self.uri, "X")
-        obsm_uri = os.path.join(self.uri, "obsm")
-        varm_uri = os.path.join(self.uri, "varm")
-        obsp_uri = os.path.join(self.uri, "obsp")
-        varp_uri = os.path.join(self.uri, "varp")
-        raw_uri = os.path.join(self.uri, "raw")
-        uns_uri = os.path.join(self.uri, "uns")
+        obs_uri = self._get_child_uri("obs")  # See comments in that function
+        var_uri = self._get_child_uri("var")
+        X_uri = self._get_child_uri("X")
+        obsm_uri = self._get_child_uri("obsm")
+        varm_uri = self._get_child_uri("varm")
+        obsp_uri = self._get_child_uri("obsp")
+        varp_uri = self._get_child_uri("varp")
+        raw_uri = self._get_child_uri("raw")
+        uns_uri = self._get_child_uri("uns")
 
         self.obs = AnnotationDataFrame(uri=obs_uri, name="obs", parent=self)
         self.var = AnnotationDataFrame(uri=var_uri, name="var", parent=self)

--- a/apis/python/src/tiledbsc/uns_group.py
+++ b/apis/python/src/tiledbsc/uns_group.py
@@ -155,7 +155,7 @@ class UnsGroup(TileDBGroup):
         self.create_unless_exists()
 
         for key in uns.keys():
-            component_uri = os.path.join(self.uri, key)
+            component_uri = self._get_child_uri(key)  # See comments in that function
             value = uns[key]
 
             if key == "rank_genes_groups":

--- a/apis/python/src/tiledbsc/util_tiledb.py
+++ b/apis/python/src/tiledbsc/util_tiledb.py
@@ -7,6 +7,7 @@ import tiledb
 
 
 # ================================================================
+# XXX FIX ME
 def show_single_cell_group(soma_uri: str, ctx: Optional[tiledb.Ctx] = None) -> None:
     """
     Show some summary information about an ingested TileDB Single-Cell Group.  This tool goes a bit beyond `print(tiledb.group.Group(soma_uri))` by also revealing array schema. Additionally, by employing encoded domain-specific knowleldge, it traverses items in the familiar order `X`, `obs`, `var`, etc. rather than using the general-purpose tiledb-group-display function.

--- a/apis/python/src/tiledbsc/util_tiledb.py
+++ b/apis/python/src/tiledbsc/util_tiledb.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python
 
-import os
 from typing import Optional
 
-import tiledbsc
 import tiledb
+
+import tiledbsc
 
 
 # ================================================================

--- a/apis/python/tools/desc-soma
+++ b/apis/python/tools/desc-soma
@@ -20,7 +20,7 @@ def main():
         sys.exit(1)
 
     for uri in sys.argv[1:]:
-        tiledbsc.util_tiledb.show_single_cell_group(uri)
+        tiledbsc.util_tiledb.show_soma_schemas(uri)
         print()
         print("METADATA:")
         soma = tiledbsc.SOMA(uri)


### PR DESCRIPTION
I'm not including unit-test cases here because of (a) credentials, and (b) clean-up associated with the tests.

I'll write up some doc-content on a separate PR. For the moment, do know that laptop -> S3/tiledb-cloud is slow. Best performance is had by running a client on a large EC2 instance in the same AWS region as the storage, or from a TileDB Cloud notebook (which does the same).

Note I have the following public on TileDB Cloud:

* `tiledb://johnkerl-tiledb/pbmc-small`
* `tiledb://johnkerl-tiledb/pbmc3k_processed`

Examples:

```
$ ingestor anndata/pbmc3k_processed.h5ad tiledb://johnkerl-tiledb/s3://tiledb-johnkerl/scdata/pbmc3k_processed
```

```
$ peek-soma tiledb://johnkerl-tiledb/pbmc3k_processed

>>> soma.uri
'tiledb://johnkerl-tiledb/pbmc3k_processed'

>>> soma.obs.uri
'tiledb://johnkerl-tiledb/df584345-28b7-45e5-abeb-043d409b1a97'

>>> soma.obs.df()
                  n_genes  percent_mito  n_counts          louvain
obs_id
AAACATACAACCAC-1      781      0.030178    2419.0      CD4 T cells
AAACATTGAGCTAC-1     1352      0.037936    4903.0          B cells
AAACATTGATCAGC-1     1131      0.008897    3147.0      CD4 T cells
AAACCGTGCTTCCG-1      960      0.017431    2639.0  CD14+ Monocytes
AAACCGTGTATGCG-1      522      0.012245     980.0         NK cells
...                   ...           ...       ...              ...
TTTCGAACTCTCAT-1     1155      0.021104    3459.0  CD14+ Monocytes
TTTCTACTGAGGCA-1     1227      0.009294    3443.0          B cells
TTTCTACTTCCTCG-1      622      0.021971    1684.0          B cells
TTTGCATGAGAGGC-1      454      0.020548    1022.0          B cells
TTTGCATGCCTCAC-1      724      0.008065    1984.0      CD4 T cells
[2638 rows x 4 columns]
```

```
# People can use the creation URIs to read, if they like -- it works either way
$ peek-soma tiledb://johnkerl-tiledb/s3://tiledb-johnkerl/scdata/pbmc3k_processed

>>> soma.uri
'tiledb://johnkerl-tiledb/s3://tiledb-johnkerl/scdata/pbmc3k_processed'

>>> soma.obs.uri
'tiledb://johnkerl-tiledb/df584345-28b7-45e5-abeb-043d409b1a97'

>>> soma.obs.df()
                  n_genes  percent_mito  n_counts          louvain
obs_id
AAACATACAACCAC-1      781      0.030178    2419.0      CD4 T cells
AAACATTGAGCTAC-1     1352      0.037936    4903.0          B cells
AAACATTGATCAGC-1     1131      0.008897    3147.0      CD4 T cells
AAACCGTGCTTCCG-1      960      0.017431    2639.0  CD14+ Monocytes
AAACCGTGTATGCG-1      522      0.012245     980.0         NK cells
...                   ...           ...       ...              ...
TTTCGAACTCTCAT-1     1155      0.021104    3459.0  CD14+ Monocytes
TTTCTACTGAGGCA-1     1227      0.009294    3443.0          B cells
TTTCTACTTCCTCG-1      622      0.021971    1684.0          B cells
TTTGCATGAGAGGC-1      454      0.020548    1022.0          B cells
TTTGCATGCCTCAC-1      724      0.008065    1984.0      CD4 T cells
[2638 rows x 4 columns]
```