### PR TITLE
Lint tools

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Check Python Black Format
         run: |
           python -m pip install black
-          python -m black --check --diff .
+          python -m black --check --diff . tools/[a-z]*
       - name: Check for unsorted / unformatted Python imports
         run: |
           python -m pip install isort
@@ -25,7 +25,7 @@ jobs:
       - name: Check Python style guide enforcement with flake8
         run: |
           python -m pip install flake8-bugbear
-          python -m flake8 .
+          python -m flake8 . tools/[a-z]*
 
 # TODO
 #      - name: Check Clang-Format

--- a/apis/python/src/tiledbsc/annotation_matrix_group.py
+++ b/apis/python/src/tiledbsc/annotation_matrix_group.py
@@ -2,7 +2,7 @@ import os
 from typing import Dict, List, Optional
 
 import pandas as pd
-import scipy
+import scipy.sparse
 import tiledb
 
 import tiledbsc.util as util

--- a/apis/python/src/tiledbsc/annotation_pairwise_matrix_group.py
+++ b/apis/python/src/tiledbsc/annotation_pairwise_matrix_group.py
@@ -1,7 +1,7 @@
 import os
 from typing import Dict, List, Optional
 
-import scipy
+import scipy.sparse
 import tiledb
 
 import tiledbsc.util as util

--- a/apis/python/src/tiledbsc/assay_matrix.py
+++ b/apis/python/src/tiledbsc/assay_matrix.py
@@ -4,7 +4,7 @@ from typing import Optional, Tuple, Union
 
 import numpy as np
 import pandas as pd
-import scipy
+import scipy.sparse
 import tiledb
 
 import tiledbsc.util as util

--- a/apis/python/src/tiledbsc/uns_array.py
+++ b/apis/python/src/tiledbsc/uns_array.py
@@ -2,7 +2,7 @@ from typing import Optional
 
 import numpy as np
 import pandas as pd
-import scipy
+import scipy.sparse
 import tiledb
 
 import tiledbsc.util as util

--- a/apis/python/src/tiledbsc/uns_group.py
+++ b/apis/python/src/tiledbsc/uns_group.py
@@ -4,7 +4,7 @@ from typing import Dict, List, Optional
 import anndata as ad
 import numpy as np
 import pandas as pd
-import scipy
+import scipy.sparse
 import tiledb
 
 import tiledbsc.util as util

--- a/apis/python/src/tiledbsc/util.py
+++ b/apis/python/src/tiledbsc/util.py
@@ -3,7 +3,6 @@ from typing import List, Optional, Union
 
 import numpy
 import pandas as pd
-import scipy
 import scipy.sparse
 import tiledb
 

--- a/apis/python/src/tiledbsc/util_ann.py
+++ b/apis/python/src/tiledbsc/util_ann.py
@@ -3,7 +3,7 @@ import os
 import anndata as ad
 import numpy as np
 import pandas as pd
-import scipy
+import scipy.sparse
 
 import tiledbsc.util as util
 

--- a/apis/python/tests/test_type_diversity.py
+++ b/apis/python/tests/test_type_diversity.py
@@ -4,8 +4,8 @@ import anndata as ad
 import numpy as np
 import pandas as pd
 import pytest
+import scipy.sparse
 import tiledb
-from scipy import sparse
 
 import tiledbsc.io as io
 from tiledbsc import SOMA
@@ -63,9 +63,9 @@ def test_from_anndata_X_type(tmp_path, X_dtype_name, X_encoding):
     if X_encoding == "dense":
         X = np.eye(n_obs, n_var, dtype=X_dtype)
     elif X_encoding == "csc":
-        X = sparse.eye(n_obs, n_var, dtype=X_dtype).tocsc()
+        X = scipy.sparse.eye(n_obs, n_var, dtype=X_dtype).tocsc()
     elif X_encoding == "csr":
-        X = sparse.eye(n_obs, n_var, dtype=X_dtype).tocsr()
+        X = scipy.sparse.eye(n_obs, n_var, dtype=X_dtype).tocsr()
 
     adata = ad.AnnData(X=X, obs=obs, var=var, dtype=X.dtype)
     assert adata.X.dtype == X_dtype  # sanity

--- a/apis/python/tools/ingestor
+++ b/apis/python/tools/ingestor
@@ -100,11 +100,11 @@ select `relative=True`. (This is the default.)
 
     if args.relative is not None:
         relative = args.relative[0]
-        if relative == 'true':
+        if relative == "true":
             soma_options.member_uris_are_relative = True
-        elif relative == 'false':
+        elif relative == "false":
             soma_options.member_uris_are_relative = False
-        elif relative == 'auto':
+        elif relative == "auto":
             soma_options.member_uris_are_relative = None
         else:
             raise Exception(f"Internal coding error in {__file__}")
@@ -220,7 +220,7 @@ def ingest_one(
                 if output_path.startswith("s3://") or output_path.startswith(
                     "tiledb://"
                 ):
-                    raise (
+                    raise Exception(
                         "--ifexists replace currently only is compatible with local-disk paths"
                     )
                 print(f"Already exists; replacing: {output_path}")

--- a/apis/python/tools/peek-ann
+++ b/apis/python/tools/peek-ann
@@ -6,20 +6,21 @@
 #
 # -- then you can inspect the anndata object.
 
-import os
 import sys
 
 import anndata
-import anndata as ad  # so we can type it either way
 import numpy
-import numpy as np  # so we can type it either way
 import pandas
-import pandas as pd  # so we can type it either way
-import scipy
-import tiledb
+import scipy  # noqa: F401
+import tiledb  # noqa: F401
 
 import tiledbsc
 import tiledbsc.io
+
+# module aliases
+ad = anndata
+np = numpy
+pd = pandas
 
 if len(sys.argv) == 1:
     input_path = "anndata/pbmc-small.h5ad"
@@ -30,10 +31,7 @@ else:
     sys.exit(1)
 
 ann = anndata.read_h5ad(input_path)
-
-
-def decat(ann):
-    return tiledbsc.util_ann._decategoricalize(ann)
+decat = tiledbsc.util_ann._decategoricalize
 
 
 # Interact at the prompt now:

--- a/apis/python/tools/peek-soco
+++ b/apis/python/tools/peek-soco
@@ -6,23 +6,21 @@
 #
 # -- then you can inspect the SOMACollection object
 
-import os
 import sys
-import time
-from typing import Dict, List
 
 import anndata
-import anndata as ad  # so we can type it either way
 import numpy
-import numpy as np  # so we can type it either way
 import pandas
-import pandas as pd  # so we can type it either way
-import scipy
-import tiledb
+import scipy  # noqa: F401
+import tiledb  # noqa: F401
 
 import tiledbsc
-import tiledbsc as t
-import tiledbsc.io as io
+import tiledbsc.io
+
+# module aliases
+ad = anndata
+np = numpy
+pd = pandas
 
 if len(sys.argv) == 1:
     soco_path = "soma-collection"
@@ -32,6 +30,6 @@ else:
     print(f"{sys.argv[0]}: need just one soma-collection path.", file=sys.stderr)
     sys.exit(1)
 
-soco = t.SOMACollection(soco_path)
+soco = tiledbsc.SOMACollection(soco_path)
 
 # Interact at the Python prompt now

--- a/apis/python/tools/peek-soma
+++ b/apis/python/tools/peek-soma
@@ -7,19 +7,20 @@
 # -- then you can inspect the soma object.
 
 import sys
-import time
 
 import anndata
-import anndata as ad  # so we can type it either way
 import numpy
-import numpy as np  # so we can type it either way
 import pandas
-import pandas as pd  # so we can type it either way
-import scipy
-import tiledb
+import scipy  # noqa: F401
+import tiledb  # noqa: F401
 
 import tiledbsc
 import tiledbsc.io
+
+# module aliases
+ad = anndata
+np = numpy
+pd = pandas
 
 if len(sys.argv) == 1:
     input_path = "tiledb-data/pbmc-small"

--- a/apis/python/tools/populate-soco
+++ b/apis/python/tools/populate-soco
@@ -48,8 +48,7 @@ def main():
     )
     parser.add_argument(
         "--relative",
-        help=
-"""
+        help="""
 * If `false` then the group will remember the absolute paths of each member array/subgroup. For
 ingesting to TileDB Cloud, this is necessary.
 
@@ -72,11 +71,11 @@ select `relative=True`. (This is the default.)
 
     if args.relative is not None:
         relative = args.relative[0]
-        if relative == 'true':
+        if relative == "true":
             soma_options.member_uris_are_relative = True
-        elif relative == 'false':
+        elif relative == "false":
             soma_options.member_uris_are_relative = False
-        elif relative == 'auto':
+        elif relative == "auto":
             soma_options.member_uris_are_relative = None
         else:
             raise Exception(f"Internal coding error in {__file__}")


### PR DESCRIPTION
- Follow up to #187 for running the linters over the tools/* scripts too.
- Consistent import of `scipy.sparse` instead of `scipy`.