### PR TITLE
Add C++ ManagedQuery

### DIFF
--- a/libtiledbsc/CMakeLists.txt
+++ b/libtiledbsc/CMakeLists.txt
@@ -182,8 +182,10 @@ endif()
 add_definitions(-D_FILE_OFFSET_BITS=64)
 
 # Disable deprecation warnings
-message(WARNING "Building without deprecation warnings")
-add_compile_options(-Wno-deprecated-declarations)
+if (NOT MSVC)
+  message(WARNING "Building without deprecation warnings")
+  add_compile_options(-Wno-deprecated-declarations)
+endif()
 
 # AVX2 flag
 include(CheckAVX2Support)

--- a/libtiledbsc/CMakeLists.txt
+++ b/libtiledbsc/CMakeLists.txt
@@ -181,6 +181,10 @@ endif()
 # Definitions for all targets
 add_definitions(-D_FILE_OFFSET_BITS=64)
 
+# Disable deprecation warnings
+message(WARNING "Building without deprecation warnings")
+add_compile_options(-Wno-deprecated-declarations)
+
 # AVX2 flag
 include(CheckAVX2Support)
 CheckAVX2Support()

--- a/libtiledbsc/cmake/Modules/FindTileDB_EP.cmake
+++ b/libtiledbsc/cmake/Modules/FindTileDB_EP.cmake
@@ -50,20 +50,20 @@ else()
     # Try to download prebuilt artifacts unless the user specifies to build from source
     if(DOWNLOAD_TILEDB_PREBUILT)
         if (WIN32) # Windows
-          SET(DOWNLOAD_URL "https://github.com/TileDB-Inc/TileDB/releases/download/2.10.0-rc0/tiledb-windows-x86_64-2.10.0-rc0-b3dd41e.zip")
-          SET(DOWNLOAD_SHA1 "1f4cb746137ee4c4166381b5314cacddc8981510")
+          SET(DOWNLOAD_URL "https://github.com/TileDB-Inc/TileDB/releases/download/2.10.0/tiledb-windows-x86_64-2.10.0-0b54e51.zip")
+          SET(DOWNLOAD_SHA1 "f5cf106b03664e9a947af7b6f59d93af14320bf4")
         elseif(APPLE) # OSX
 
           if (CMAKE_OSX_ARCHITECTURES STREQUAL x86_64 OR CMAKE_SYSTEM_PROCESSOR MATCHES "(x86_64)|(AMD64|amd64)|(^i.86$)")
-            SET(DOWNLOAD_URL "https://github.com/TileDB-Inc/TileDB/releases/download/2.10.0-rc0/tiledb-macos-x86_64-2.10.0-rc0-b3dd41e.tar.gz")
-            SET(DOWNLOAD_SHA1 "4f1cd7d68d3b86f016b1058d8a1a93b65fe89e64")
+            SET(DOWNLOAD_URL "https://github.com/TileDB-Inc/TileDB/releases/download/2.10.0/tiledb-macos-x86_64-2.10.0-0b54e51.tar.gz")
+            SET(DOWNLOAD_SHA1 "cff7beabc19cf4cde636689628abccdacdee5e9b")
           elseif (CMAKE_OSX_ARCHITECTURES STREQUAL arm64 OR CMAKE_SYSTEM_PROCESSOR MATCHES "^aarch64" OR CMAKE_SYSTEM_PROCESSOR MATCHES "^arm")
-            SET(DOWNLOAD_URL "https://github.com/TileDB-Inc/TileDB/releases/download/2.10.0-rc0/tiledb-macos-arm64-2.10.0-rc0-b3dd41e.tar.gz")
-            SET(DOWNLOAD_SHA1 "461cfd0a565a8210102efc8e4e341c54f2f74b23")
+            SET(DOWNLOAD_URL "https://github.com/TileDB-Inc/TileDB/releases/download/2.10.0/tiledb-macos-arm64-2.10.0-0b54e51.tar.gz")
+            SET(DOWNLOAD_SHA1 "d1ad00ac6faeadc84e349a4851d1299492b4160a")
           endif()
         else() # Linux
-          SET(DOWNLOAD_URL "https://github.com/TileDB-Inc/TileDB/releases/download/2.10.0-rc0/tiledb-linux-x86_64-2.10.0-rc0-b3dd41e.tar.gz")
-          SET(DOWNLOAD_SHA1 "2d6ab82ad69b0e9a5566783dcd044480874c3f57")
+          SET(DOWNLOAD_URL "https://github.com/TileDB-Inc/TileDB/releases/download/2.10.0/tiledb-linux-x86_64-2.10.0-0b54e51.tar.gz")
+          SET(DOWNLOAD_SHA1 "edde8df085e22aedf487af7ca9eb2632f8190a8f")
         endif()
 
         ExternalProject_Add(ep_tiledb
@@ -85,8 +85,8 @@ else()
     else() # Build from source
         ExternalProject_Add(ep_tiledb
           PREFIX "externals"
-          URL "https://github.com/TileDB-Inc/TileDB/archive/2.10.0-rc0.zip"
-          URL_HASH SHA1=897aa75fcde443121cfd2121bbdab7886b84f7da
+          URL "https://github.com/TileDB-Inc/TileDB/archive/2.10.0.zip"
+          URL_HASH SHA1=34f3bbfd70daea6cf4378d54d191e05ff427c7c6
           DOWNLOAD_NAME "tiledb.zip"
           CMAKE_ARGS
             -DCMAKE_INSTALL_PREFIX=${EP_INSTALL_PREFIX}

--- a/libtiledbsc/include/tiledbsc/managed_query.h
+++ b/libtiledbsc/include/tiledbsc/managed_query.h
@@ -2,10 +2,12 @@
 #define MANAGED_QUERY_H
 
 #include <stdexcept>  // for windows: error C2039: 'runtime_error': is not a member of 'std'
+#include <unordered_set>
 
 #include <tiledb/tiledb>
 
 #include "tiledbsc/column_buffer.h"
+#include "tiledbsc/common.h"
 
 namespace tiledbsc {
 
@@ -15,16 +17,34 @@ constexpr size_t TILEDBSC_DEFAULT_ALLOC = 524288;
 
 class ManagedQuery {
    public:
+    //===================================================================
+    //= public non-static
+    //===================================================================
+
+    /**
+     * @brief Construct a new Managed Query object
+     *
+     * @param array TileDB array
+     * @param initial_cells Initial number of cells to allocate
+     */
     ManagedQuery(
         std::shared_ptr<Array> array,
         size_t initial_cells = TILEDBSC_DEFAULT_ALLOC);
 
-    void select_columns(std::vector<std::string> names) {
-        for (auto& name : names) {
-            columns_.insert(name);
-        }
-    }
+    /**
+     * @brief Select columns names to query (dim and attr).
+     *
+     * @param names Vector of column names
+     */
+    void select_columns(std::vector<std::string> names);
 
+    /**
+     * @brief Select dimension ranges to query.
+     *
+     * @tparam T Dimension type
+     * @param dim Dimension name
+     * @param ranges Vector of dimension ranges
+     */
     template <typename T>
     void select_ranges(
         const std::string& dim, std::vector<std::pair<T, T>> ranges) {
@@ -33,6 +53,13 @@ class ManagedQuery {
         }
     }
 
+    /**
+     * @brief Select dimension points to query.
+     *
+     * @tparam T Dimension type
+     * @param dim Dimension name
+     * @param points Vector of dimension points
+     */
     template <typename T>
     void select_points(const std::string& dim, std::vector<T> points) {
         for (auto& point : points) {
@@ -40,26 +67,89 @@ class ManagedQuery {
         }
     }
 
+    /**
+     * @brief Execute the query and return the number of cells read.
+     * To handle possible incomplete queries, `execute()` must be called until
+     * it returns 0, which indicated the query is complete.
+     *
+     * For example:
+     *   while (auto num_cells = mq.execute()) {
+     *     // process the results
+     *   }
+     *
+     * @return size_t Number of cells read. Returns 0 when the read is complete.
+     */
     size_t execute();
 
+    /**
+     * @brief Return a view of data in column `name`.
+     *
+     * @tparam T Data type
+     * @param name Column name
+     * @return std::span<T> Data view
+     */
     template <typename T>
     std::span<T> data(const std::string& name) {
+        check_column_name(name);
         return buffers_.at(name)->data<T>();
     }
 
+    /**
+     * @brief Return a vector of strings from the column `name`.
+     *
+     * @param name Column name
+     * @return std::vector<std::string> Strings
+     */
     std::vector<std::string> strings(const std::string& name) {
+        check_column_name(name);
         return buffers_.at(name)->strings();
     }
 
+    /**
+     * @brief Return a string_view of the string at the provided cell index from
+     * column `name`.
+     *
+     * @param name Column name
+     * @param index Cell index
+     * @return std::string_view String view
+     */
     std::string_view string_view(const std::string& name, uint64_t index) {
+        check_column_name(name);
         return buffers_.at(name)->string_view(index);
     }
 
    private:
+    //===================================================================
+    //= private non-static
+    //===================================================================
+
+    /**
+     * @brief Check if column name is contained in the query results.
+     *
+     * @param name Column name
+     */
+    void check_column_name(const std::string& name) {
+        if (!buffers_.contains(name)) {
+            throw TileDBSCError(fmt::format(
+                "[ManagedQuery] Column '{}' is not available in the query "
+                "results.",
+                name));
+        }
+    }
+
+    // TileDB array being queried.
     std::shared_ptr<Array> array_;
+
+    // Initial number of cells to allocate for each ColumnBuffer.
     size_t initial_cells_;
+
+    // TileDB query being managed.
     std::unique_ptr<Query> query_;
-    std::set<std::string> columns_;
+
+    // Set of column names to read (dim and attr). If empty, query all columns.
+    std::unordered_set<std::string> columns_;
+
+    // Map of column name to ColumnBuffer.
     std::unordered_map<std::string, std::shared_ptr<ColumnBuffer>> buffers_;
 };
 

--- a/libtiledbsc/include/tiledbsc/managed_query.h
+++ b/libtiledbsc/include/tiledbsc/managed_query.h
@@ -1,6 +1,8 @@
 #ifndef MANAGED_QUERY_H
 #define MANAGED_QUERY_H
 
+#include <stdexcept>  // for windows: error C2039: 'runtime_error': is not a member of 'std'
+
 #include <tiledb/tiledb>
 
 #include "tiledbsc/column_buffer.h"

--- a/libtiledbsc/include/tiledbsc/managed_query.h
+++ b/libtiledbsc/include/tiledbsc/managed_query.h
@@ -1,0 +1,66 @@
+#ifndef MANAGED_QUERY_H
+#define MANAGED_QUERY_H
+
+#include <tiledb/tiledb>
+
+#include "tiledbsc/column_buffer.h"
+
+namespace tiledbsc {
+
+using namespace tiledb;
+
+constexpr size_t TILEDBSC_DEFAULT_ALLOC = 524288;
+
+class ManagedQuery {
+   public:
+    ManagedQuery(
+        std::shared_ptr<Array> array,
+        size_t initial_cells = TILEDBSC_DEFAULT_ALLOC);
+
+    void select_columns(std::vector<std::string> names) {
+        for (auto& name : names) {
+            columns_.insert(name);
+        }
+    }
+
+    template <typename T>
+    void select_ranges(
+        const std::string& dim, std::vector<std::pair<T, T>> ranges) {
+        for (auto& [start, stop] : ranges) {
+            query_->add_range(dim, start, stop);
+        }
+    }
+
+    template <typename T>
+    void select_points(const std::string& dim, std::vector<T> points) {
+        for (auto& point : points) {
+            query_->add_range(dim, point, point);
+        }
+    }
+
+    size_t execute();
+
+    template <typename T>
+    std::span<T> data(const std::string& name) {
+        return buffers_.at(name)->data<T>();
+    }
+
+    std::vector<std::string> strings(const std::string& name) {
+        return buffers_.at(name)->strings();
+    }
+
+    std::string_view string_view(const std::string& name, uint64_t index) {
+        return buffers_.at(name)->string_view(index);
+    }
+
+   private:
+    std::shared_ptr<Array> array_;
+    size_t initial_cells_;
+    std::unique_ptr<Query> query_;
+    std::set<std::string> columns_;
+    std::unordered_map<std::string, std::shared_ptr<ColumnBuffer>> buffers_;
+};
+
+};  // namespace tiledbsc
+
+#endif

--- a/libtiledbsc/include/tiledbsc/soma.h
+++ b/libtiledbsc/include/tiledbsc/soma.h
@@ -65,7 +65,7 @@ class SOMA {
      * @param name Name of the array to open
      * @return Array TileDB array
      */
-    Array open_array(const std::string& name);
+    std::shared_ptr<Array> open_array(const std::string& name);
 
     auto context() {
         return ctx_;

--- a/libtiledbsc/include/tiledbsc/tiledbsc
+++ b/libtiledbsc/include/tiledbsc/tiledbsc
@@ -3,6 +3,8 @@
 
 #include <tiledbsc/column_buffer.h>
 #include <tiledbsc/common.h>
+#include <tiledbsc/logger_public.h>
+#include <tiledbsc/managed_query.h>
 #include <tiledbsc/soma.h>
 #include <tiledbsc/soma_collection.h>
 // TODO: #include <tiledbsc/soma_query.h>

--- a/libtiledbsc/include/tiledbsc/util.h
+++ b/libtiledbsc/include/tiledbsc/util.h
@@ -1,0 +1,21 @@
+#ifndef UTIL_H
+#define UTIL_H
+
+#include <tiledbsc/tiledbsc>
+
+namespace tiledbsc::util {
+
+using VarlenBufferPair =
+    std::pair<std::vector<std::byte>, std::vector<uint64_t>>;
+
+template <typename T>
+VarlenBufferPair to_varlen_buffers(std::vector<T> data, bool arrow = true);
+
+template <class T>
+std::vector<T> to_vector(const std::span<T>& s) {
+    return std::vector<T>(s.begin(), s.end());
+}
+
+}  // namespace tiledbsc::util
+
+#endif

--- a/libtiledbsc/include/tiledbsc/util.h
+++ b/libtiledbsc/include/tiledbsc/util.h
@@ -1,6 +1,8 @@
 #ifndef UTIL_H
 #define UTIL_H
 
+#include <stdexcept>  // for windows: error C2039: 'runtime_error': is not a member of 'std'
+
 #include <tiledbsc/tiledbsc>
 
 namespace tiledbsc::util {

--- a/libtiledbsc/src/CMakeLists.txt
+++ b/libtiledbsc/src/CMakeLists.txt
@@ -47,8 +47,10 @@ message(STATUS "Building with commit hash ${BUILD_COMMIT_HASH}")
 add_library(TILEDB_SC_OBJECTS OBJECT
   ${CMAKE_CURRENT_SOURCE_DIR}/column_buffer.cc
   ${CMAKE_CURRENT_SOURCE_DIR}/logger.cc
+  ${CMAKE_CURRENT_SOURCE_DIR}/managed_query.cc
   ${CMAKE_CURRENT_SOURCE_DIR}/soma_collection.cc
   ${CMAKE_CURRENT_SOURCE_DIR}/soma.cc
+  ${CMAKE_CURRENT_SOURCE_DIR}/util.cc
 )
 
 message(WARNING "Building without deprecation warnings")

--- a/libtiledbsc/src/cli.cc
+++ b/libtiledbsc/src/cli.cc
@@ -1,7 +1,6 @@
 // This file is currently a sandbox for C++ API experiments
 
 #include <tiledbsc/tiledbsc>
-#include "tiledbsc/logger_public.h"
 
 using namespace tiledbsc;
 
@@ -24,65 +23,24 @@ void walk_soco(std::string_view uri) {
 
 void slice_soma(std::string_view soma_uri) {
     Config conf;
-    conf["config.logging_level"] = "5";
-    //    Context ctx(conf);
+    // conf["config.logging_level"] = "5";
 
     auto soma = SOMA::open(soma_uri, conf);
-    auto array = soma.open_array("obs");
-    auto ctx = soma.context();  // only need this for query, move to SOMQuery
-    Query query(*ctx, array, TILEDB_READ);
-    query.set_layout(TILEDB_UNORDERED);
+    auto mq = ManagedQuery(soma.open_array("obs"));
 
-    std::string obs_id = "obs_id";
-    std::string count = "percent_mito";
+    mq.select_columns({"obs_id", "percent_mito"});
+    mq.select_points<std::string>("obs_id", {"AAACATACAACCAC-1"});
+    mq.select_ranges<std::string>(
+        "obs_id", {{"TTTCGAACTCTCAT-1", "TTTGCATGCCTCAC-1"}});
 
-    auto est = query.est_result_size_var(obs_id);
-    LOG_INFO(fmt::format("est = {} {}", est[0], est[1]));
-
-    auto buffer = ColumnBuffer::create(array, obs_id, 1 << 22);
-    buffer.attach(query);
-    auto buffer1 = ColumnBuffer::create(array, count, 1 << 22);
-    buffer1.attach(query);
-
-    Query::Status status;
-    do {
-        // Submit query and get status
-        query.submit();
-        status = query.query_status();
-        buffer.resize(query);
-        buffer1.resize(query);
-
-        // IMPORTANT: check if there are any results, as your buffer
-        // could have been too small to fit even a single result
-        auto results = query.result_buffer_elements()[obs_id].first;
-        bool has_results = query.result_buffer_elements()[obs_id].second != 0;
-        auto offsets = buffer.offsets();
-
-        LOG_INFO(fmt::format("status={} results={}", status, results));
-        if (status == Query::Status::INCOMPLETE && !has_results) {
-            // You need to reallocate your buffers, otherwise
-            // you will get an infinite loop
-            printf("buffers too small\n");
-            return;
-        } else if (has_results) {
-            //            auto data = (float*)bg.data_.data();
-            //            auto data = std::string_view(
-            //(char*)bg.data_.data(), bg.offsets_.value()[1]);
-            // auto value = "TBD";  // std::string(data.begin(), offsets[1]);
-            auto value = buffer.string_view(0);
-            LOG_INFO(fmt::format("value = {} len = {}", value, value.size()));
-            LOG_INFO(fmt::format("value = {}", buffer1.data<float>()[0]));
-
-            value = buffer.string_view(results - 1);
-            LOG_INFO(
-                fmt::format("last_value = {} len = {}", value, value.size()));
-            LOG_INFO(
-                fmt::format("value = {}", buffer1.data<float>()[results - 1]));
+    while (auto num_cells = mq.execute()) {
+        for (size_t i = 0; i < num_cells; i++) {
+            LOG_INFO(fmt::format(
+                "obs_id = {} percent_mito = {}",
+                mq.string_view("obs_id", i),
+                mq.data<float>("percent_mito")[i]));
         }
-    } while (status == Query::Status::INCOMPLETE);
-
-    // Close the array
-    array.close();
+    }
 }
 
 int main(int argc, char** argv) {

--- a/libtiledbsc/src/managed_query.cc
+++ b/libtiledbsc/src/managed_query.cc
@@ -1,0 +1,70 @@
+#include "tiledbsc/managed_query.h"
+#include "tiledbsc/common.h"
+#include "tiledbsc/logger_public.h"
+
+namespace tiledbsc {
+
+ManagedQuery::ManagedQuery(std::shared_ptr<Array> array, size_t initial_cells)
+    : array_(array)
+    , initial_cells_(initial_cells) {
+    query_ = std::make_unique<Query>(array->schema().context(), *array);
+
+    if (array->schema().array_type() == TILEDB_SPARSE) {
+        query_->set_layout(TILEDB_UNORDERED);
+    } else {
+        query_->set_layout(TILEDB_ROW_MAJOR);
+    }
+}
+
+size_t ManagedQuery::execute() {
+    auto status = query_->query_status();
+
+    // Query is complete, return 0 cells read
+    if (status == Query::Status::COMPLETE) {
+        return 0;
+    }
+
+    // Query is uninitialized, allocate and attach buffers
+    if (status == Query::Status::UNINITIALIZED) {
+        // If no columns were selected, select all columns
+        if (!columns_.size()) {
+            for (const auto& dim : array_->schema().domain().dimensions()) {
+                columns_.insert(dim.name());
+            }
+            for (const auto& [name, attr] : array_->schema().attributes()) {
+                (void)attr;
+                columns_.insert(name);
+            }
+        }
+
+        // Allocate and attach buffers
+        for (auto& name : columns_) {
+            LOG_DEBUG(fmt::format("Adding buffer for column '{}'", name));
+            buffers_.emplace(
+                name, ColumnBuffer::create(array_, name, initial_cells_));
+            buffers_[name]->attach(*query_);
+        }
+    }
+
+    // Submit query
+    query_->submit();
+    status = query_->query_status();
+    LOG_DEBUG(fmt::format("Query status = {}", (int)status));
+
+    // Update ColumnBuffer size to match query results
+    size_t num_cells = 0;
+    for (auto& [name, buffer] : buffers_) {
+        num_cells = buffer->update_size(*query_);
+        LOG_DEBUG(fmt::format("Buffer {} cells={}", name, num_cells));
+    }
+
+    // TODO: retry the query with larger buffers
+    if (status == Query::Status::INCOMPLETE && !num_cells) {
+        throw TileDBSCError(fmt::format(
+            "[ManagedQuery] Buffers are too small: {} cells", initial_cells_));
+    }
+
+    return num_cells;
+}
+
+};  // namespace tiledbsc

--- a/libtiledbsc/src/managed_query.cc
+++ b/libtiledbsc/src/managed_query.cc
@@ -4,6 +4,12 @@
 
 namespace tiledbsc {
 
+using namespace tiledb;
+
+//===================================================================
+//= public non-static
+//===================================================================
+
 ManagedQuery::ManagedQuery(std::shared_ptr<Array> array, size_t initial_cells)
     : array_(array)
     , initial_cells_(initial_cells) {
@@ -13,6 +19,12 @@ ManagedQuery::ManagedQuery(std::shared_ptr<Array> array, size_t initial_cells)
         query_->set_layout(TILEDB_UNORDERED);
     } else {
         query_->set_layout(TILEDB_ROW_MAJOR);
+    }
+}
+
+void ManagedQuery::select_columns(std::vector<std::string> names) {
+    for (auto& name : names) {
+        columns_.insert(name);
     }
 }
 

--- a/libtiledbsc/src/soma.cc
+++ b/libtiledbsc/src/soma.cc
@@ -37,13 +37,13 @@ std::unordered_map<std::string, std::string> SOMA::list_arrays() {
     return array_uri_map_;
 }
 
-Array SOMA::open_array(const std::string& name) {
+std::shared_ptr<Array> SOMA::open_array(const std::string& name) {
     if (array_uri_map_.empty()) {
         list_arrays();
     }
     auto uri = array_uri_map_[name];
     LOG_DEBUG(fmt::format("Opening array '{}' from SOMA '{}'", name, uri_));
-    return Array(*ctx_, uri, TILEDB_READ);
+    return std::make_shared<Array>(*ctx_, uri, TILEDB_READ);
 }
 
 //===================================================================

--- a/libtiledbsc/src/util.cc
+++ b/libtiledbsc/src/util.cc
@@ -1,0 +1,36 @@
+#include "tiledbsc/util.h"
+
+namespace tiledbsc::util {
+
+template <typename T>
+VarlenBufferPair to_varlen_buffers(std::vector<T> data, bool arrow) {
+    size_t nbytes = 0;
+    for (auto& elem : data) {
+        nbytes += elem.size();
+    }
+
+    std::vector<std::byte> result(nbytes);
+    std::vector<uint64_t> offsets(data.size() + 1);
+    size_t offset = 0;
+    size_t idx = 0;
+
+    for (auto& elem : data) {
+        std::memcpy(result.data() + offset, elem.data(), elem.size());
+        offsets[idx++] = offset;
+
+        offset += elem.size();
+    }
+    offsets[idx] = offset;
+
+    // Remove extra arrow offset when creating buffers for TileDB write
+    if (!arrow) {
+        offsets.pop_back();
+    }
+
+    return {result, offsets};
+}
+
+template VarlenBufferPair to_varlen_buffers(
+    std::vector<std::string>, bool arrow);
+
+};  // namespace tiledbsc::util

--- a/libtiledbsc/test/CMakeLists.txt
+++ b/libtiledbsc/test/CMakeLists.txt
@@ -41,7 +41,7 @@ if (TILEDBSC_TESTING)
 
     add_test(
         NAME "unit_sc"
-        COMMAND $<TARGET_FILE:unit_sc>
+        COMMAND $<TARGET_FILE:unit_sc> "--durations=yes"
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
     )
 

--- a/libtiledbsc/test/CMakeLists.txt
+++ b/libtiledbsc/test/CMakeLists.txt
@@ -22,6 +22,7 @@ if (TILEDBSC_TESTING)
     add_executable(unit_sc EXCLUDE_FROM_ALL
         $<TARGET_OBJECTS:TILEDB_SC_OBJECTS>
         unit_column_buffer.cc
+        unit_managed_query.cc
     )
 
     target_link_libraries(unit_sc

--- a/libtiledbsc/test/unit_column_buffer.cc
+++ b/libtiledbsc/test/unit_column_buffer.cc
@@ -11,6 +11,8 @@ using namespace tiledbsc;
 
 const std::string src_path = TILEDBSC_SOURCE_ROOT;
 
+namespace {
+
 /**
  * @brief Create an array and return array opened in read mode.
  *
@@ -43,6 +45,8 @@ static std::shared_ptr<Array> create_array(
     Array::create(uri, schema);
     return std::make_shared<Array>(ctx, uri, TILEDB_READ);
 }
+
+};  // namespace
 
 TEST_CASE("ColumnBuffer: Create from attribute") {
     auto ctx = Context();

--- a/libtiledbsc/test/unit_column_buffer.cc
+++ b/libtiledbsc/test/unit_column_buffer.cc
@@ -11,43 +11,22 @@ using namespace tiledbsc;
 
 const std::string src_path = TILEDBSC_SOURCE_ROOT;
 
-TEST_CASE("ColumnBuffer: Create from attribute") {
-    auto ctx = Context();
+/**
+ * @brief Create an array and return array opened in read mode.
+ *
+ * @param uri Array uri
+ * @param ctx TileDB context
+ * @return std::shared_ptr<Array>
+ */
+static std::shared_ptr<Array> create_array(
+    const std::string& uri, Context& ctx) {
+    // delete array if it exists
+    auto vfs = VFS(ctx);
+    if (vfs.is_dir(uri)) {
+        vfs.remove_dir(uri);
+    }
 
-    auto attr = Attribute::create<int32_t>(ctx, "a1");
-    attr.set_nullable(true);
-    attr.set_cell_val_num(TILEDB_VAR_NUM);
-
-    auto buffers = ColumnBuffer::create(attr, 21);
-
-    REQUIRE(buffers.name() == "a1");
-    REQUIRE(buffers.is_var() == true);
-    REQUIRE(buffers.is_nullable() == true);
-    REQUIRE(buffers.data<int32_t>().size() == 21);
-    REQUIRE(buffers.offsets().size() == 22);
-    REQUIRE(buffers.validity().size() == 21);
-}
-
-TEST_CASE("ColumnBuffer: Create from dimension") {
-    auto ctx = Context();
-    auto dim = Dimension::create(
-        ctx, "d1", TILEDB_STRING_ASCII, nullptr, nullptr);
-    dim.set_cell_val_num(TILEDB_VAR_NUM);
-
-    auto buffers = ColumnBuffer::create(dim, 9);
-
-    REQUIRE(buffers.name() == "d1");
-    REQUIRE(buffers.is_var() == true);
-    REQUIRE(buffers.is_nullable() == false);
-    REQUIRE(buffers.data<char>().size() == 9);
-    REQUIRE(buffers.offsets().size() == 10);
-    REQUIRE(buffers.validity().size() == 0);
-}
-
-TEST_CASE("ColumnBuffer: Create from array") {
-    auto ctx = Context();
     ArraySchema schema(ctx, TILEDB_SPARSE);
-
     auto dim = Dimension::create(
         ctx, "d1", TILEDB_STRING_ASCII, nullptr, nullptr);
     dim.set_cell_val_num(TILEDB_VAR_NUM);
@@ -61,27 +40,65 @@ TEST_CASE("ColumnBuffer: Create from array") {
     attr.set_cell_val_num(TILEDB_VAR_NUM);
     schema.add_attribute(attr);
 
-    auto uri = "mem://temp";
     Array::create(uri, schema);
-    auto array = Array(ctx, uri, TILEDB_READ);
+    return std::make_shared<Array>(ctx, uri, TILEDB_READ);
+}
+
+TEST_CASE("ColumnBuffer: Create from attribute") {
+    auto ctx = Context();
+
+    auto attr = Attribute::create<int32_t>(ctx, "a1");
+    attr.set_nullable(true);
+    attr.set_cell_val_num(TILEDB_VAR_NUM);
+
+    auto buffers = ColumnBuffer::create(attr, 21);
+
+    REQUIRE(buffers->name() == "a1");
+    REQUIRE(buffers->is_var() == true);
+    REQUIRE(buffers->is_nullable() == true);
+    REQUIRE(buffers->data<int32_t>().size() == 21);
+    REQUIRE(buffers->offsets().size() == 22);
+    REQUIRE(buffers->validity().size() == 21);
+}
+
+TEST_CASE("ColumnBuffer: Create from dimension") {
+    auto ctx = Context();
+    auto dim = Dimension::create(
+        ctx, "d1", TILEDB_STRING_ASCII, nullptr, nullptr);
+    dim.set_cell_val_num(TILEDB_VAR_NUM);
+
+    auto buffers = ColumnBuffer::create(dim, 9);
+
+    REQUIRE(buffers->name() == "d1");
+    REQUIRE(buffers->is_var() == true);
+    REQUIRE(buffers->is_nullable() == false);
+    REQUIRE(buffers->data<char>().size() == 9);
+    REQUIRE(buffers->offsets().size() == 10);
+    REQUIRE(buffers->validity().size() == 0);
+}
+
+TEST_CASE("ColumnBuffer: Create from array") {
+    std::string uri = "mem://unit-test-array";
+    auto ctx = Context();
+    auto array = create_array(uri, ctx);
 
     {
         auto buffers = ColumnBuffer::create(array, "d1", 9);
-        REQUIRE(buffers.name() == "d1");
-        REQUIRE(buffers.is_var() == true);
-        REQUIRE(buffers.is_nullable() == false);
-        REQUIRE(buffers.data<char>().size() == 9);
-        REQUIRE(buffers.offsets().size() == 10);
-        REQUIRE(buffers.validity().size() == 0);
+        REQUIRE(buffers->name() == "d1");
+        REQUIRE(buffers->is_var() == true);
+        REQUIRE(buffers->is_nullable() == false);
+        REQUIRE(buffers->data<char>().size() == 9);
+        REQUIRE(buffers->offsets().size() == 10);
+        REQUIRE(buffers->validity().size() == 0);
     }
 
     {
         auto buffers = ColumnBuffer::create(array, "a1", 21);
-        REQUIRE(buffers.name() == "a1");
-        REQUIRE(buffers.is_var() == true);
-        REQUIRE(buffers.is_nullable() == true);
-        REQUIRE(buffers.data<int32_t>().size() == 21);
-        REQUIRE(buffers.offsets().size() == 22);
-        REQUIRE(buffers.validity().size() == 21);
+        REQUIRE(buffers->name() == "a1");
+        REQUIRE(buffers->is_var() == true);
+        REQUIRE(buffers->is_nullable() == true);
+        REQUIRE(buffers->data<int32_t>().size() == 21);
+        REQUIRE(buffers->offsets().size() == 22);
+        REQUIRE(buffers->validity().size() == 21);
     }
 }

--- a/libtiledbsc/test/unit_managed_query.cc
+++ b/libtiledbsc/test/unit_managed_query.cc
@@ -1,0 +1,86 @@
+#include <catch2/catch_template_test_macros.hpp>
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_exception.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+#include <catch2/matchers/catch_matchers_predicate.hpp>
+#include <catch2/matchers/catch_matchers_string.hpp>
+#include <catch2/matchers/catch_matchers_templated.hpp>
+#include <catch2/matchers/catch_matchers_vector.hpp>
+#include <random>
+
+#include <tiledbsc/util.h>
+#include <tiledb/tiledb>
+#include <tiledbsc/tiledbsc>
+
+using namespace tiledb;
+using namespace tiledbsc;
+using namespace Catch::Matchers;
+
+#ifndef TILEDBSC_SOURCE_ROOT
+#define TILEDBSC_SOURCE_ROOT "not_defined"
+#endif
+
+const std::string src_path = TILEDBSC_SOURCE_ROOT;
+
+namespace {
+static auto create_array(const std::string& uri, Context& ctx) {
+    // Delete array if it exists
+    auto vfs = VFS(ctx);
+    if (vfs.is_dir(uri)) {
+        vfs.remove_dir(uri);
+    }
+
+    // Create schema
+    ArraySchema schema(ctx, TILEDB_SPARSE);
+    auto dim = Dimension::create(
+        ctx, "d0", TILEDB_STRING_ASCII, nullptr, nullptr);
+    dim.set_cell_val_num(TILEDB_VAR_NUM);
+
+    Domain domain(ctx);
+    domain.add_dimension(dim);
+    schema.set_domain(domain);
+
+    auto attr = Attribute::create<int>(ctx, "a0");
+    schema.add_attribute(attr);
+    schema.check();
+
+    // Create array and open for writing
+    Array::create(uri, schema);
+    Array array(ctx, uri, TILEDB_WRITE);
+
+    std::vector<std::string> d0 = {
+        "a", "bb", "ccc", "dddd", "eeeee", "fffffff"};
+    auto [d0_data, d0_offsets] = util::to_varlen_buffers(d0, false);
+
+    std::vector<int> a0(d0.size());
+    std::generate(a0.begin(), a0.end(), std::default_random_engine());
+
+    // Write data to array and close the array
+    Query query(ctx, array);
+    query.set_layout(TILEDB_UNORDERED)
+        .set_buffer("d0", d0_data)
+        .set_offsets_buffer("d0", d0_offsets)
+        .set_buffer("a0", a0);
+    query.submit();
+    array.close();
+
+    // Open the array for reading and return a shared pointer
+    return std::tuple(std::make_shared<Array>(ctx, uri, TILEDB_READ), d0, a0);
+}
+
+};  // namespace
+
+TEST_CASE("ManagedQuery: Basic execution test") {
+    std::string uri = "mem://unit-test-array";
+    auto ctx = Context();
+    auto [array, d0, a0] = create_array(uri, ctx);
+
+    auto mq = ManagedQuery(array);
+    mq.select_columns({"d0", "a0"});
+
+    auto num_cells = mq.execute();
+
+    REQUIRE(num_cells == d0.size());
+    REQUIRE_THAT(d0, Equals(mq.strings("d0")));
+    REQUIRE_THAT(a0, Equals(util::to_vector(mq.data<int>("a0"))));
+}


### PR DESCRIPTION
Add ManagedQuery class which provides a nice API for querying TileDB arrays.

Example code:
```c++
    // Open SOMA
    auto soma = SOMA::open(soma_uri);

    // Create ManagedQuery for "obs" array
    auto mq = ManagedQuery(soma.open_array("obs"));

    // Select columns to materialize
    mq.select_columns({"obs_id", "percent_mito"});
 
    // Select dimension points and ranges to query
    mq.select_points<std::string>("obs_id", {"AAACATACAACCAC-1"});
    mq.select_ranges<std::string>(
        "obs_id", {{"TTTCGAACTCTCAT-1", "TTTGCATGCCTCAC-1"}});

    // Execute query and loop until complete (in case of an incomplete query)
    while (auto num_cells = mq.execute()) {
        // Get std::span view of "percent_mito" data
        auto mito = mq.data<float>("percent_mito");
        for (size_t i = 0; i < num_cells; i++) {
            // Get string_view of "obs_id"
            auto obs = mq.string_view("obs_id", i);
            LOG_INFO(
                fmt::format("obs_id = {} percent_mito = {}", obs, mito[i]));
        }
    }
```

Example output:
```
[2022-06-24 17:02:44.286] [tiledbsc] [Process: 407667] [Thread: 407667] [info] obs_id = AAACATACAACCAC-1 percent_mito = 0.030177759
[2022-06-24 17:02:44.286] [tiledbsc] [Process: 407667] [Thread: 407667] [info] obs_id = TTTCGAACTCTCAT-1 percent_mito = 0.021104366
[2022-06-24 17:02:44.286] [tiledbsc] [Process: 407667] [Thread: 407667] [info] obs_id = TTTCTACTGAGGCA-1 percent_mito = 0.00929422
[2022-06-24 17:02:44.286] [tiledbsc] [Process: 407667] [Thread: 407667] [info] obs_id = TTTCTACTTCCTCG-1 percent_mito = 0.021971496
[2022-06-24 17:02:44.286] [tiledbsc] [Process: 407667] [Thread: 407667] [info] obs_id = TTTGCATGAGAGGC-1 percent_mito = 0.020547945
[2022-06-24 17:02:44.286] [tiledbsc] [Process: 407667] [Thread: 407667] [info] obs_id = TTTGCATGCCTCAC-1 percent_mito = 0.008064516

```