### PR TITLE
Update to tiledb-py 0.16.1

### DIFF
--- a/apis/python/setup.cfg
+++ b/apis/python/setup.cfg
@@ -30,7 +30,7 @@ packges = tiledbsc
 platforms = any
 zip_safe = False
 install_requires =
-    tiledb>=0.16.0
+    tiledb>=0.16.1
     scipy
     pandas
     pyarrow


### PR DESCRIPTION
This brings in bugfix release https://pypi.org/project/tiledb/0.16.1 from `tiledb-py`.