### PR TITLE
Make it easier to see progress indicators in notebook ingests

### DIFF
--- a/apis/python/examples/uniformizer.py
+++ b/apis/python/examples/uniformizer.py
@@ -51,10 +51,7 @@ def main() -> int:
     args = parser.parse_args()
 
     if args.verbose:
-        tiledbsc.logging.logger.setLevel(logging.INFO)
-        logger = logging.getLogger("tiledbsc")
-        logger.setLevel(logging.INFO)
-        logger.addHandler(logging.StreamHandler())
+        tiledbsc.logging.info()
 
     uniformizer = Uniformizer(
         atlas_uri=args.atlas_uri,

--- a/apis/python/src/tiledbsc/logging.py
+++ b/apis/python/src/tiledbsc/logging.py
@@ -1,3 +1,21 @@
 import logging
 
 logger = logging.getLogger(__name__)  # Nominally __name__ is 'tiledbsc'
+
+
+def info():
+    """
+    Sets tiledbsc logging to an INFO level. Use `tiledbsc.logging.info()` in notebooks to see
+    progress indicators for data ingestion.
+    """
+    logger.setLevel(logging.INFO)
+    logger.addHandler(logging.StreamHandler())
+
+
+def warning():
+    """
+    Sets tiledbsc logging to a WARNING level. Use `tiledbsc.logging.info()` in notebooks to suppress
+    progress indicators for data ingestion.
+    """
+    logger.setLevel(logging.WARNING)
+    logger.addHandler(logging.StreamHandler())

--- a/apis/python/tools/ingestor
+++ b/apis/python/tools/ingestor
@@ -100,10 +100,7 @@ select `relative=True`. (This is the default.)
     write_soco = args.soco
     verbose = not args.quiet
     if verbose:
-        tiledbsc.logging.logger.setLevel(logging.INFO)
-        logger = logging.getLogger("tiledbsc")
-        logger.setLevel(logging.INFO)
-        logger.addHandler(logging.StreamHandler())
+        tiledbsc.logging.info()
 
     if args.relative is not None:
         relative = args.relative[0]

--- a/apis/python/tools/outgestor
+++ b/apis/python/tools/outgestor
@@ -78,10 +78,7 @@ def main():
 
     verbose = not args.quiet
     if verbose:
-        tiledbsc.logging.logger.setLevel(logging.INFO)
-        logger = logging.getLogger("tiledbsc")
-        logger.setLevel(logging.INFO)
-        logger.addHandler(logging.StreamHandler())
+        tiledbsc.logging.info()
 
     soma = tiledbsc.SOMA(input_path)
     tiledbsc.io.to_h5ad(soma, output_path)


### PR DESCRIPTION
Ever since #186, data-ingestion in notebooks is silent by default, with no ready recourse. This is disturbing and unhelpful.

Here we retain silent-by-default, but we implement a one-liner, to be used in example notebooks, to give users a comforting reassurance that the ingestion cell is, indeed, "doing something".