### PR TITLE
Allow users to add new matrices to obsm,varm,obsp,varp

### DIFF
--- a/apis/python/src/tiledbsc/annotation_matrix_group.py
+++ b/apis/python/src/tiledbsc/annotation_matrix_group.py
@@ -70,31 +70,34 @@ class AnnotationMatrixGroup(TileDBGroup):
         return self[name]
 
     # ----------------------------------------------------------------
-    def from_matrices_and_dim_values(self, annotation_matrices, dim_values) -> None:
+    def add_layer_from_matrix_and_dim_values(
+        self,
+        matrix,
+        dim_values,
+        matrix_name: str,
+    ) -> None:
         """
-        Populates the `obsm` or `varm` subgroup for a SOMA object, then writes all the components
-        arrays under that group.
+        Populates a component of the `obsm` or `varm` subgroup for a SOMA object.
 
-        :param annotation_matrices: anndata.obsm, anndata.varm, or anndata.raw.varm.
+        :param matrix: element of anndata.obsm, anndata.varm, or anndata.raw.varm.
         :param dim_values: anndata.obs_names, anndata.var_names, or anndata.raw.var_names.
+        :param matrix_name_name: name of the matrix, like `"X_tsne"` or `"PCs"`.
         """
 
         # Must be done first, to create the parent directory
         self.create_unless_exists()
 
-        for matrix_name in annotation_matrices.keys():
-            anndata_matrix = annotation_matrices[matrix_name]
-            matrix_uri = self._get_child_uri(
-                matrix_name
-            )  # See comments in that function
-            annotation_matrix = AnnotationMatrix(
-                uri=matrix_uri,
-                name=matrix_name,
-                dim_name=self.dim_name,
-                parent=self,
-            )
-            annotation_matrix.from_matrix_and_dim_values(anndata_matrix, dim_values)
-            self._add_object(annotation_matrix)
+        # See comments in that function
+        matrix_uri = self._get_child_uri(matrix_name)
+
+        annotation_matrix = AnnotationMatrix(
+            uri=matrix_uri,
+            name=matrix_name,
+            dim_name=self.dim_name,
+            parent=self,
+        )
+        annotation_matrix.from_matrix_and_dim_values(matrix, dim_values)
+        self._add_object(annotation_matrix)
 
     # ----------------------------------------------------------------
     def to_dict_of_csr(self) -> Dict[str, scipy.sparse.csr_matrix]:

--- a/apis/python/src/tiledbsc/annotation_matrix_group.py
+++ b/apis/python/src/tiledbsc/annotation_matrix_group.py
@@ -70,7 +70,7 @@ class AnnotationMatrixGroup(TileDBGroup):
         return self[name]
 
     # ----------------------------------------------------------------
-    def add_layer_from_matrix_and_dim_values(
+    def add_matrix_from_matrix_and_dim_values(
         self,
         matrix,
         dim_values,

--- a/apis/python/src/tiledbsc/annotation_pairwise_matrix_group.py
+++ b/apis/python/src/tiledbsc/annotation_pairwise_matrix_group.py
@@ -89,7 +89,7 @@ class AnnotationPairwiseMatrixGroup(TileDBGroup):
         return iter(retval)
 
     # ----------------------------------------------------------------
-    def add_layer_from_matrix_and_dim_values(
+    def add_matrix_from_matrix_and_dim_values(
         self,
         matrix,
         dim_values,

--- a/apis/python/src/tiledbsc/annotation_pairwise_matrix_group.py
+++ b/apis/python/src/tiledbsc/annotation_pairwise_matrix_group.py
@@ -89,39 +89,41 @@ class AnnotationPairwiseMatrixGroup(TileDBGroup):
         return iter(retval)
 
     # ----------------------------------------------------------------
-    def from_matrices_and_dim_values(
-        self, annotation_pairwise_matrices, dim_values
+    def add_layer_from_matrix_and_dim_values(
+        self,
+        matrix,
+        dim_values,
+        matrix_name: str,
     ) -> None:
         """
-        Populates the `obsp` or `varp` subgroup for a SOMA object, then writes all the components
-        arrays under that group.
+        Populates a component of the `obsp` or `varp` subgroup for a SOMA object.
 
-        :param annotation_pairwise_matrices: anndata.obsp, anndata.varp, or anndata.raw.varp.
-        :param dim_values: anndata.obs_names, anndata.var_names, or anndata.raw.var_names.
+        :param matrix: element of anndata.obsp or anndata.varp.
+        :param dim_values: anndata.obs_names or anndata.var_names.
+        :param matrix_name_name: name of the matrix, like `"distances"`.
         """
 
         # Must be done first, to create the parent directory
         self.create_unless_exists()
-        for matrix_name in annotation_pairwise_matrices.keys():
-            anndata_matrix = annotation_pairwise_matrices[matrix_name]
-            matrix_uri = self._get_child_uri(
-                matrix_name
-            )  # See comments in that function
-            annotation_pairwise_matrix = AssayMatrix(
-                uri=matrix_uri,
-                name=matrix_name,
-                row_dim_name=self.row_dim_name,
-                col_dim_name=self.col_dim_name,
-                row_dataframe=self.row_dataframe,
-                col_dataframe=self.col_dataframe,
-                parent=self,
-            )
-            annotation_pairwise_matrix.from_matrix_and_dim_values(
-                anndata_matrix,
-                dim_values,
-                dim_values,
-            )
-            self._add_object(annotation_pairwise_matrix)
+
+        # See comments in that function
+        matrix_uri = self._get_child_uri(matrix_name)
+
+        annotation_pairwise_matrix = AssayMatrix(
+            uri=matrix_uri,
+            name=matrix_name,
+            row_dim_name=self.row_dim_name,
+            col_dim_name=self.col_dim_name,
+            row_dataframe=self.row_dataframe,
+            col_dataframe=self.col_dataframe,
+            parent=self,
+        )
+        annotation_pairwise_matrix.from_matrix_and_dim_values(
+            matrix,
+            dim_values,
+            dim_values,
+        )
+        self._add_object(annotation_pairwise_matrix)
 
     # ----------------------------------------------------------------
     def to_dict_of_csr(

--- a/apis/python/src/tiledbsc/io.py
+++ b/apis/python/src/tiledbsc/io.py
@@ -125,28 +125,28 @@ def from_anndata(soma: tiledbsc.SOMA, anndata: ad.AnnData) -> None:
     # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
     soma.obsm.create_unless_exists()
     for key in anndata.obsm.keys():
-        soma.obsm.add_layer_from_matrix_and_dim_values(
+        soma.obsm.add_matrix_from_matrix_and_dim_values(
             anndata.obsm[key], anndata.obs_names, key
         )
     soma._add_object(soma.obsm)
 
     soma.varm.create_unless_exists()
     for key in anndata.varm.keys():
-        soma.varm.add_layer_from_matrix_and_dim_values(
+        soma.varm.add_matrix_from_matrix_and_dim_values(
             anndata.varm[key], anndata.var_names, key
         )
     soma._add_object(soma.varm)
 
     soma.obsp.create_unless_exists()
     for key in anndata.obsp.keys():
-        soma.obsp.add_layer_from_matrix_and_dim_values(
+        soma.obsp.add_matrix_from_matrix_and_dim_values(
             anndata.obsp[key], anndata.obs_names, key
         )
     soma._add_object(soma.obsp)
 
     soma.varp.create_unless_exists()
     for key in anndata.varp.keys():
-        soma.varp.add_layer_from_matrix_and_dim_values(
+        soma.varp.add_matrix_from_matrix_and_dim_values(
             anndata.varp[key], anndata.var_names, key
         )
     soma._add_object(soma.varp)

--- a/apis/python/src/tiledbsc/io.py
+++ b/apis/python/src/tiledbsc/io.py
@@ -123,16 +123,32 @@ def from_anndata(soma: tiledbsc.SOMA, anndata: ad.AnnData) -> None:
     soma._add_object(soma.X)
 
     # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-    soma.obsm.from_matrices_and_dim_values(anndata.obsm, anndata.obs_names)
+    soma.obsm.create_unless_exists()
+    for key in anndata.obsm.keys():
+        soma.obsm.add_layer_from_matrix_and_dim_values(
+            anndata.obsm[key], anndata.obs_names, key
+        )
     soma._add_object(soma.obsm)
 
-    soma.varm.from_matrices_and_dim_values(anndata.varm, anndata.var_names)
+    soma.varm.create_unless_exists()
+    for key in anndata.varm.keys():
+        soma.varm.add_layer_from_matrix_and_dim_values(
+            anndata.varm[key], anndata.var_names, key
+        )
     soma._add_object(soma.varm)
 
-    soma.obsp.from_matrices_and_dim_values(anndata.obsp, anndata.obs_names)
+    soma.obsp.create_unless_exists()
+    for key in anndata.obsp.keys():
+        soma.obsp.add_layer_from_matrix_and_dim_values(
+            anndata.obsp[key], anndata.obs_names, key
+        )
     soma._add_object(soma.obsp)
 
-    soma.varp.from_matrices_and_dim_values(anndata.varp, anndata.var_names)
+    soma.varp.create_unless_exists()
+    for key in anndata.varp.keys():
+        soma.varp.add_layer_from_matrix_and_dim_values(
+            anndata.varp[key], anndata.var_names, key
+        )
     soma._add_object(soma.varp)
 
     # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

--- a/apis/python/src/tiledbsc/raw_group.py
+++ b/apis/python/src/tiledbsc/raw_group.py
@@ -85,7 +85,7 @@ class RawGroup(TileDBGroup):
 
         self.varm.create_unless_exists()
         for key in anndata.raw.varm.keys():
-            self.varm.add_layer_from_matrix_and_dim_values(
+            self.varm.add_matrix_from_matrix_and_dim_values(
                 anndata.raw.varm[key], anndata.raw.var_names, key
             )
         self._add_object(self.varm)

--- a/apis/python/src/tiledbsc/raw_group.py
+++ b/apis/python/src/tiledbsc/raw_group.py
@@ -83,7 +83,11 @@ class RawGroup(TileDBGroup):
         )
         self._add_object(self.X)
 
-        self.varm.from_matrices_and_dim_values(anndata.raw.varm, anndata.raw.var_names)
+        self.varm.create_unless_exists()
+        for key in anndata.raw.varm.keys():
+            self.varm.add_layer_from_matrix_and_dim_values(
+                anndata.raw.varm[key], anndata.raw.var_names, key
+            )
         self._add_object(self.varm)
 
         logger.info(util.format_elapsed(s, f"{self._indent}FINISH WRITING {self.uri}"))

--- a/apis/python/tests/test_add_layer.py
+++ b/apis/python/tests/test_add_layer.py
@@ -43,11 +43,28 @@ def test_add_layer(adata):
         for j in range(0, num_cols):
             csr[i, j] = i + j
 
+    # Add X layer
     soma.X.add_layer_from_matrix_and_dim_values(
         csr, soma.obs.ids(), soma.var.ids(), "data2"
     )
 
     csr2 = soma.X.data2.csr()
     assert csr2.shape == orig_shape
+
+    # Add obsm matrix
+    soma.obsm.add_layer_from_matrix_and_dim_values(
+        soma.obsm.X_tsne.df(), soma.obs_keys(), "voila"
+    )
+    assert sorted(soma.obsm.keys()) == ["X_pca", "X_tsne", "voila"]
+    assert soma.obsm.voila.shape() == soma.obsm.X_tsne.shape()
+
+    # Add obsp matrix
+    soma.obsp.add_layer_from_matrix_and_dim_values(
+        soma.obsp.distances.csr(),
+        soma.obs_keys(),
+        "voici",
+    )
+    assert sorted(soma.obsp.keys()) == ["distances", "voici"]
+    assert soma.obsp.voici.shape() == soma.obsp.distances.shape()
 
     tempdir.cleanup()

--- a/apis/python/tests/test_add_layer.py
+++ b/apis/python/tests/test_add_layer.py
@@ -52,14 +52,14 @@ def test_add_layer(adata):
     assert csr2.shape == orig_shape
 
     # Add obsm matrix
-    soma.obsm.add_layer_from_matrix_and_dim_values(
+    soma.obsm.add_matrix_from_matrix_and_dim_values(
         soma.obsm.X_tsne.df(), soma.obs_keys(), "voila"
     )
     assert sorted(soma.obsm.keys()) == ["X_pca", "X_tsne", "voila"]
     assert soma.obsm.voila.shape() == soma.obsm.X_tsne.shape()
 
     # Add obsp matrix
-    soma.obsp.add_layer_from_matrix_and_dim_values(
+    soma.obsp.add_matrix_from_matrix_and_dim_values(
         soma.obsp.distances.csr(),
         soma.obs_keys(),
         "voici",


### PR DESCRIPTION
```
>>> soma.obsm.keys()
['X_tsne', 'X_pca']
```

```
>>> soma.obsm.add_layer_from_matrix_and_dim_values(soma.obsm.X_tsne.df(), soma.obs_keys(), 'voila')
```

```
>>> soma.obsm.keys()
['X_pca', 'X_tsne', 'voila']

>>> soma.obsm.voila.df()
                 X_tsne_1   X_tsne_2
obs_id
AAATTCGAATCACG -31.988231 -16.622181
AAGCAAGAGCTTAG  15.682430 -26.610128
AAGCGACTTTGACG -31.919623  -0.864304
AATGCGTGGACGGA  -1.839384  22.204006
AATGTTGACAGTCA  16.964273  -9.429598
...                   ...        ...
TTACGTACGTTCAG  41.689558  20.468961
TTGAGGACTACGCA -18.422789  22.004794
TTGCATTGAGCTAC  -6.034624   4.744967
TTGGTACTGAATCC   4.517332   8.024611
TTTAGCTGTACTCT  -3.208584  21.943824

[80 rows x 2 columns]
```