### PR TITLE
Make a simple default display for SOMA objects in notebooks

### DIFF
--- a/apis/python/src/tiledbsc/annotation_dataframe.py
+++ b/apis/python/src/tiledbsc/annotation_dataframe.py
@@ -78,6 +78,13 @@ class AnnotationDataFrame(TileDBArray):
             return [e.decode() for e in retval]
 
     # ----------------------------------------------------------------
+    def __repr__(self) -> str:
+        """
+        Default display of soma.obs and soma.var.
+        """
+        return ", ".join(f"'{key}'" for key in self.keys())
+
+    # ----------------------------------------------------------------
     def __len__(self) -> int:
         """
         Implements `len(soma.obs)` and `len(soma.var)`.

--- a/apis/python/src/tiledbsc/annotation_matrix_group.py
+++ b/apis/python/src/tiledbsc/annotation_matrix_group.py
@@ -44,6 +44,13 @@ class AnnotationMatrixGroup(TileDBGroup):
         return self._get_member_names()
 
     # ----------------------------------------------------------------
+    def __repr__(self) -> str:
+        """
+        Default display of soma.obsm and soma.varm.
+        """
+        return ", ".join(f"'{key}'" for key in self.keys())
+
+    # ----------------------------------------------------------------
     def __iter__(self) -> List[AnnotationMatrix]:
         """
         Implements `for matrix in soma.obsm: ...` and `for matrix in soma.varm: ...`

--- a/apis/python/src/tiledbsc/annotation_pairwise_matrix_group.py
+++ b/apis/python/src/tiledbsc/annotation_pairwise_matrix_group.py
@@ -57,6 +57,13 @@ class AnnotationPairwiseMatrixGroup(TileDBGroup):
         return self._get_member_names()
 
     # ----------------------------------------------------------------
+    def __repr__(self) -> str:
+        """
+        Default display of soma.obsp and soma.varp.
+        """
+        return ", ".join(f"'{key}'" for key in self.keys())
+
+    # ----------------------------------------------------------------
     def __getattr__(self, name) -> AssayMatrix:
         """
         This is called on `soma.obsp.name` when `name` is not already an attribute.

--- a/apis/python/src/tiledbsc/assay_matrix_group.py
+++ b/apis/python/src/tiledbsc/assay_matrix_group.py
@@ -52,6 +52,13 @@ class AssayMatrixGroup(TileDBGroup):
         return self._get_member_names()
 
     # ----------------------------------------------------------------
+    def __repr__(self) -> str:
+        """
+        Default display of soma.X.
+        """
+        return ", ".join(f"'{key}'" for key in self.keys())
+
+    # ----------------------------------------------------------------
     def __getattr__(self, name) -> AssayMatrix:
         """
         This is called on `soma.X.name` when `name` is not already an attribute.

--- a/apis/python/src/tiledbsc/soma.py
+++ b/apis/python/src/tiledbsc/soma.py
@@ -154,6 +154,8 @@ class SOMA(TileDBGroup):
                 lines.append("raw/var: " + repr(self.raw.var))
             # repr(self.uns) is very chatty (too chatty) for some datasets:
             lines.append("uns:     " + ", ".join(self.uns.keys()))
+        else:
+            lines.append("Unpopulated")
 
         return "\n".join(lines)
 

--- a/apis/python/src/tiledbsc/soma.py
+++ b/apis/python/src/tiledbsc/soma.py
@@ -131,11 +131,31 @@ class SOMA(TileDBGroup):
         # * data_uri is "tiledb://namespace/s3://bucketname/something/test1/X"
 
     # ----------------------------------------------------------------
-    def __str__(self):
+    def __repr__(self) -> str:
         """
-        Implements `print(soma)`.
+        Default display of SOMA.
         """
-        return f"name={self.name},uri={self.uri}"
+
+        lines = [
+            "Name:    " + self.name,
+            "URI:     " + self.uri,
+        ]
+        if self.exists():
+            lines.append(f"(n_obs, n_var): ({len(self.obs)}, {len(self.var)})")
+            lines.append("X:       " + repr(self.X))
+            lines.append("obs:     " + repr(self.obs))
+            lines.append("var:     " + repr(self.var))
+            lines.append("obsm:    " + repr(self.obsm))
+            lines.append("varm:    " + repr(self.varm))
+            lines.append("obsp:    " + repr(self.obsp))
+            lines.append("varp:    " + repr(self.varp))
+            if self.raw.exists():
+                lines.append("raw/X:   " + repr(self.raw.X))
+                lines.append("raw/var: " + repr(self.raw.var))
+            # repr(self.uns) is very chatty (too chatty) for some datasets:
+            lines.append("uns:     " + ", ".join(self.uns.keys()))
+
+        return "\n".join(lines)
 
     # ----------------------------------------------------------------
     def __getattr__(self, name):

--- a/apis/python/src/tiledbsc/soma_collection.py
+++ b/apis/python/src/tiledbsc/soma_collection.py
@@ -43,6 +43,16 @@ class SOMACollection(TileDBGroup):
         )
 
     # ----------------------------------------------------------------
+    def __repr__(self) -> str:
+        """
+        Default display of SOMACollection.
+        """
+        lines = ["URI:        " + self.uri, ]
+        if self.exists():
+            lines.append(f"SOMA count: {len(self)}")
+        return "\n".join(lines)
+
+    # ----------------------------------------------------------------
     def __len__(self) -> int:
         """
         Implements `len(soco)`. Returns the number of elements in the collection.

--- a/apis/python/src/tiledbsc/soma_collection.py
+++ b/apis/python/src/tiledbsc/soma_collection.py
@@ -47,9 +47,13 @@ class SOMACollection(TileDBGroup):
         """
         Default display of SOMACollection.
         """
-        lines = ["URI:        " + self.uri, ]
+        lines = [
+            "URI:        " + self.uri,
+        ]
         if self.exists():
             lines.append(f"SOMA count: {len(self)}")
+        else:
+            lines.append("Unpopulated")
         return "\n".join(lines)
 
     # ----------------------------------------------------------------


### PR DESCRIPTION
## Before

```
>>> soma
<tiledbsc.soma.SOMA object at 0x7f98d0b33b80>
```

## After

```
>>> soma
Name:    pbmc-small
URI:     tiledb-data/pbmc-small
(n_obs, n_var): (80, 20)
X:       'data'
obs:     'orig.ident', 'nCount_RNA', 'nFeature_RNA', 'RNA_snn_res.0.8', 'letter.idents', 'groups', 'RNA_snn_res.1'
var:     'vst.mean', 'vst.variance', 'vst.variance.expected', 'vst.variance.standardized', 'vst.variable'
obsm:    'X_tsne', 'X_pca'
varm:    'PCs'
obsp:    'distances'
varp:
raw/X:   'data'
raw/var: 'vst.mean', 'vst.variance', 'vst.variance.expected', 'vst.variance.standardized', 'vst.variable'
uns:     neighbors
```