### PR TITLE
Support quiet/info/debug levels for data ingest

### DIFF
--- a/apis/python/src/tiledbsc/annotation_dataframe.py
+++ b/apis/python/src/tiledbsc/annotation_dataframe.py
@@ -1,3 +1,4 @@
+import os
 from typing import List, Optional, Set, Tuple
 
 import numpy as np
@@ -6,7 +7,7 @@ import tiledb
 
 import tiledbsc.util as util
 
-from .logging import logger
+from .logging import log_io
 from .tiledb_array import TileDBArray
 from .tiledb_group import TileDBGroup
 
@@ -204,7 +205,7 @@ class AnnotationDataFrame(TileDBArray):
         attr_filters = tiledb.FilterList([tiledb.ZstdFilter(level=-1)])
 
         s = util.get_start_stamp()
-        logger.info(f"{self._indent}START  WRITING {self.uri}")
+        log_io(None, f"{self._indent}START  WRITING {self.uri}")
 
         # Make the row-names column (barcodes for obs, gene names for var) explicitly named.
         # Otherwise it'll be called '__tiledb_rows'.
@@ -234,7 +235,7 @@ class AnnotationDataFrame(TileDBArray):
         mode = "ingest"
         if self.exists():
             mode = "append"
-            logger.info(f"{self._indent}Re-using existing array {self.uri}")
+            log_io(None, f"{self._indent}Re-using existing array {self.uri}")
 
         # ISSUE:
         # TileDB attributes can be stored as Unicode but they are not yet queryable via the TileDB
@@ -287,4 +288,7 @@ class AnnotationDataFrame(TileDBArray):
 
         self._set_object_type_metadata()
 
-        logger.info(util.format_elapsed(s, f"{self._indent}FINISH WRITING {self.uri}"))
+        log_io(
+            os.path.basename(self.uri),
+            util.format_elapsed(s, f"{self._indent}FINISH WRITING {self.uri}"),
+        )

--- a/apis/python/src/tiledbsc/annotation_matrix.py
+++ b/apis/python/src/tiledbsc/annotation_matrix.py
@@ -1,3 +1,4 @@
+import os
 from typing import Optional, Tuple
 
 import pandas as pd
@@ -5,7 +6,7 @@ import tiledb
 
 import tiledbsc.util as util
 
-from .logging import logger
+from .logging import log_io
 from .tiledb_array import TileDBArray
 from .tiledb_group import TileDBGroup
 
@@ -98,7 +99,7 @@ class AnnotationMatrix(TileDBArray):
         """
 
         s = util.get_start_stamp()
-        logger.info(f"{self._indent}START  WRITING {self.uri}")
+        log_io(None, f"{self._indent}START  WRITING {self.uri}")
 
         if isinstance(matrix, pd.DataFrame):
             self._from_pandas_dataframe(matrix, dim_values)
@@ -107,7 +108,10 @@ class AnnotationMatrix(TileDBArray):
 
         self._set_object_type_metadata()
 
-        logger.info(util.format_elapsed(s, f"{self._indent}FINISH WRITING {self.uri}"))
+        log_io(
+            os.path.basename(self.uri),
+            util.format_elapsed(s, f"{self._indent}FINISH WRITING {self.uri}"),
+        )
 
     # ----------------------------------------------------------------
     def _numpy_ndarray_or_scipy_sparse_csr_matrix(self, matrix, dim_values) -> None:
@@ -119,7 +123,7 @@ class AnnotationMatrix(TileDBArray):
 
         # Ingest annotation matrices as 1D/multi-attribute sparse arrays
         if self.exists():
-            logger.info(f"{self._indent}Re-using existing array {self.uri}")
+            log_io(None, f"{self._indent}Re-using existing array {self.uri}")
         else:
             self._create_empty_array([matrix.dtype] * nattr, attr_names)
 
@@ -132,7 +136,7 @@ class AnnotationMatrix(TileDBArray):
 
         # Ingest annotation matrices as 1D/multi-attribute sparse arrays
         if self.exists():
-            logger.info(f"{self._indent}Re-using existing array {self.uri}")
+            log_io(None, f"{self._indent}Re-using existing array {self.uri}")
         else:
             self._create_empty_array(list(df.dtypes), attr_names)
 

--- a/apis/python/src/tiledbsc/annotation_matrix_group.py
+++ b/apis/python/src/tiledbsc/annotation_matrix_group.py
@@ -8,7 +8,7 @@ import tiledb
 import tiledbsc.util as util
 
 from .annotation_matrix import AnnotationMatrix
-from .logging import logger
+from .logging import log_io
 from .tiledb_group import TileDBGroup
 
 
@@ -114,17 +114,17 @@ class AnnotationMatrixGroup(TileDBGroup):
         if (
             not self.exists()
         ):  # Not all groups have all four of obsm, obsp, varm, and varp.
-            logger.info(f"{self._indent}{self.uri} not found")
+            log_io(None, f"{self._indent}{self.uri} not found")
             return {}
 
         s = util.get_start_stamp()
-        logger.info(f"{self._indent}START  read {self.uri}")
+        log_io(None, f"{self._indent}START  read {self.uri}")
 
         with self._open() as G:
             matrices_in_group = {}
             for element in G:
                 s2 = util.get_start_stamp()
-                logger.info(f"{self._indent}START  read {element.uri}")
+                log_io(None, f"{self._indent}START  read {element.uri}")
 
                 with tiledb.open(element.uri, ctx=self._ctx) as A:
                     df = pd.DataFrame(A[:])
@@ -132,11 +132,15 @@ class AnnotationMatrixGroup(TileDBGroup):
                     matrix_name = os.path.basename(element.uri)  # e.g. 'X_pca'
                     matrices_in_group[matrix_name] = df.to_numpy()
 
-                logger.info(
-                    util.format_elapsed(s2, f"{self._indent}FINISH read {element.uri}")
+                log_io(
+                    "",
+                    util.format_elapsed(s2, f"{self._indent}FINISH read {element.uri}"),
                 )
 
-        logger.info(util.format_elapsed(s, f"{self._indent}FINISH read {self.uri}"))
+        log_io(
+            os.path.basename(self.uri),
+            util.format_elapsed(s, f"{self._indent}FINISH read {self.uri}"),
+        )
 
         return matrices_in_group
 

--- a/apis/python/src/tiledbsc/annotation_pairwise_matrix_group.py
+++ b/apis/python/src/tiledbsc/annotation_pairwise_matrix_group.py
@@ -8,7 +8,7 @@ import tiledbsc.util as util
 
 from .annotation_dataframe import AnnotationDataFrame
 from .assay_matrix import AssayMatrix
-from .logging import logger
+from .logging import log_io
 from .tiledb_group import TileDBGroup
 
 
@@ -145,29 +145,33 @@ class AnnotationPairwiseMatrixGroup(TileDBGroup):
         except tiledb.TileDBError:
             pass
         if grp is None:
-            logger.info(f"{self._indent}{self.uri} not found")
+            log_io(None, f"{self._indent}{self.uri} not found")
             return {}
 
         s = util.get_start_stamp()
-        logger.info(f"{self._indent}START  read {self.uri}")
+        log_io(None, f"{self._indent}START  read {self.uri}")
 
         matrices_in_group = {}
         for element in self:
             s2 = util.get_start_stamp()
-            logger.info(f"{self._indent}START  read {element.uri}")
+            log_io(None, f"{self._indent}START  read {element.uri}")
 
             matrix_name = os.path.basename(element.uri)  # TODO: fix for tiledb cloud
             matrices_in_group[matrix_name] = element.to_csr_matrix(
                 obs_df_index, var_df_index
             )
 
-            logger.info(
-                util.format_elapsed(s2, f"{self._indent}FINISH read {element.uri}")
+            log_io(
+                None,
+                util.format_elapsed(s2, f"{self._indent}FINISH read {element.uri}"),
             )
 
         grp.close()
 
-        logger.info(util.format_elapsed(s, f"{self._indent}FINISH read {self.uri}"))
+        log_io(
+            os.path.basename(self.uri),
+            util.format_elapsed(s, f"{self._indent}FINISH WRITING {self.uri}"),
+        )
 
         return matrices_in_group
 

--- a/apis/python/src/tiledbsc/io.py
+++ b/apis/python/src/tiledbsc/io.py
@@ -6,7 +6,7 @@ import tiledbsc
 import tiledbsc.util
 import tiledbsc.util_ann
 
-from .logging import logger
+from .logging import log_io
 
 
 # ----------------------------------------------------------------
@@ -32,23 +32,25 @@ def _from_h5ad_common(soma: tiledbsc.SOMA, input_path: str, handler_func) -> Non
     Common code for things we do when processing a .h5ad file for ingest/update.
     """
     s = tiledbsc.util.get_start_stamp()
-    logger.info(f"START  SOMA.from_h5ad {input_path} -> {soma.uri}")
+    log_io(None, f"START  SOMA.from_h5ad {input_path} -> {soma.uri}")
 
     s = tiledbsc.util.get_start_stamp()
-    logger.info(f"{soma._indent}START  READING {input_path}")
+    log_io(None, f"{soma._indent}START  READING {input_path}")
 
     anndata = ad.read_h5ad(input_path)
 
-    logger.info(
-        tiledbsc.util.format_elapsed(s, f"{soma._indent}FINISH READING {input_path}")
+    log_io(
+        None,
+        tiledbsc.util.format_elapsed(s, f"{soma._indent}FINISH READING {input_path}"),
     )
 
     handler_func(soma, anndata)
 
-    logger.info(
+    log_io(
+        None,
         tiledbsc.util.format_elapsed(
             s, f"FINISH SOMA.from_h5ad {input_path} -> {soma.uri}"
-        )
+        ),
     )
 
 
@@ -58,22 +60,24 @@ def from_10x(soma: tiledbsc.SOMA, input_path: str) -> None:
     Reads a 10X file and writes to a TileDB group structure.
     """
     s = tiledbsc.util.get_start_stamp()
-    logger.info(f"START  SOMA.from_10x {input_path} -> {soma.uri}")
+    log_io(None, f"START  SOMA.from_10x {input_path} -> {soma.uri}")
 
-    logger.info(f"{soma._indent}START  READING {input_path}")
+    log_io(None, f"{soma._indent}START  READING {input_path}")
 
     anndata = scanpy.read_10x_h5(input_path)
 
-    logger.info(
-        tiledbsc.util.format_elapsed(s, f"{soma._indent}FINISH READING {input_path}")
+    log_io(
+        None,
+        tiledbsc.util.format_elapsed(s, f"{soma._indent}FINISH READING {input_path}"),
     )
 
     from_anndata(soma, anndata)
 
-    logger.info(
+    log_io(
+        None,
         tiledbsc.util.format_elapsed(
             s, f"FINISH SOMA.from_10x {input_path} -> {soma.uri}"
-        )
+        ),
     )
 
     return anndata
@@ -90,18 +94,19 @@ def from_anndata(soma: tiledbsc.SOMA, anndata: ad.AnnData) -> None:
         raise NotImplementedError("Empty AnnData.obs or AnnData.var unsupported.")
 
     s = tiledbsc.util.get_start_stamp()
-    logger.info(f"{soma._indent}START  DECATEGORICALIZING")
+    log_io(None, f"{soma._indent}START  DECATEGORICALIZING")
 
     anndata.obs_names_make_unique()
     anndata.var_names_make_unique()
     anndata = tiledbsc.util_ann._decategoricalize(anndata)
 
-    logger.info(
-        tiledbsc.util.format_elapsed(s, f"{soma._indent}FINISH DECATEGORICALIZING")
+    log_io(
+        None,
+        tiledbsc.util.format_elapsed(s, f"{soma._indent}FINISH DECATEGORICALIZING"),
     )
 
     s = tiledbsc.util.get_start_stamp()
-    logger.info(f"{soma._indent}START  WRITING {soma.uri}")
+    log_io(None, f"{soma._indent}START  WRITING {soma.uri}")
 
     # Must be done first, to create the parent directory
     soma.create_unless_exists()
@@ -161,8 +166,9 @@ def from_anndata(soma: tiledbsc.SOMA, anndata: ad.AnnData) -> None:
         soma.uns.from_anndata_uns(anndata.uns)
         soma._add_object(soma.uns)
 
-    logger.info(
-        tiledbsc.util.format_elapsed(s, f"{soma._indent}FINISH WRITING {soma.uri}")
+    log_io(
+        None,
+        tiledbsc.util.format_elapsed(s, f"{soma._indent}FINISH WRITING {soma.uri}"),
     )
 
 
@@ -178,18 +184,19 @@ def from_anndata_update_obs_and_var(soma: tiledbsc.SOMA, anndata: ad.AnnData) ->
         raise NotImplementedError("Empty AnnData.obs or AnnData.var unsupported.")
 
     s = tiledbsc.util.get_start_stamp()
-    logger.info(f"{soma._indent}START  DECATEGORICALIZING")
+    log_io(None, f"{soma._indent}START  DECATEGORICALIZING")
 
     anndata.obs_names_make_unique()
     anndata.var_names_make_unique()
     anndata = tiledbsc.util_ann._decategoricalize(anndata)
 
-    logger.info(
-        tiledbsc.util.format_elapsed(s, f"{soma._indent}FINISH DECATEGORICALIZING")
+    log_io(
+        None,
+        tiledbsc.util.format_elapsed(s, f"{soma._indent}FINISH DECATEGORICALIZING"),
     )
 
     s = tiledbsc.util.get_start_stamp()
-    logger.info(f"{soma._indent}START  WRITING {soma.uri}")
+    log_io(None, f"{soma._indent}START  WRITING {soma.uri}")
 
     # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
     soma._remove_object(soma.obs)
@@ -204,8 +211,9 @@ def from_anndata_update_obs_and_var(soma: tiledbsc.SOMA, anndata: ad.AnnData) ->
     tiledb.consolidate(soma.var.uri)
     tiledb.vacuum(soma.var.uri)
 
-    logger.info(
-        tiledbsc.util.format_elapsed(s, f"{soma._indent}FINISH WRITING {soma.uri}")
+    log_io(
+        None,
+        tiledbsc.util.format_elapsed(s, f"{soma._indent}FINISH WRITING {soma.uri}"),
     )
 
 
@@ -217,23 +225,25 @@ def to_h5ad(soma: tiledbsc.SOMA, h5ad_path: str) -> None:
     """
 
     s = tiledbsc.util.get_start_stamp()
-    logger.info(f"START  SOMA.to_h5ad {soma.uri} -> {h5ad_path}")
+    log_io(None, f"START  SOMA.to_h5ad {soma.uri} -> {h5ad_path}")
 
     anndata = to_anndata(soma)
 
     s2 = tiledbsc.util.get_start_stamp()
-    logger.info(f"{soma._indent}START  write {h5ad_path}")
+    log_io(None, f"{soma._indent}START  write {h5ad_path}")
 
     anndata.write_h5ad(h5ad_path)
 
-    logger.info(
-        tiledbsc.util.format_elapsed(s2, f"{soma._indent}FINISH write {h5ad_path}")
+    log_io(
+        None,
+        tiledbsc.util.format_elapsed(s2, f"{soma._indent}FINISH write {h5ad_path}"),
     )
 
-    logger.info(
+    log_io(
+        None,
         tiledbsc.util.format_elapsed(
             s, f"FINISH SOMA.to_h5ad {soma.uri} -> {h5ad_path}"
-        )
+        ),
     )
 
 
@@ -250,7 +260,7 @@ def to_anndata(soma: tiledbsc.SOMA) -> ad.AnnData:
     """
 
     s = tiledbsc.util.get_start_stamp()
-    logger.info(f"START  SOMA.to_anndata {soma.uri}")
+    log_io(None, f"START  SOMA.to_anndata {soma.uri}")
 
     obs_df = soma.obs.df()
     var_df = soma.var.df()
@@ -294,7 +304,7 @@ def to_anndata(soma: tiledbsc.SOMA) -> ad.AnnData:
         uns=uns,
     )
 
-    logger.info(tiledbsc.util.format_elapsed(s, f"FINISH SOMA.to_anndata {soma.uri}"))
+    log_io(None, tiledbsc.util.format_elapsed(s, f"FINISH SOMA.to_anndata {soma.uri}"))
 
     return anndata
 

--- a/apis/python/src/tiledbsc/logging.py
+++ b/apis/python/src/tiledbsc/logging.py
@@ -1,4 +1,5 @@
 import logging
+from typing import Union
 
 logger = logging.getLogger("tiledbsc")
 
@@ -24,7 +25,7 @@ def debug():
     Sets tiledbsc logging to an DEBUG level. Use `tiledbsc.logging.debug()` in notebooks to see more
     detailed progress indicators for data ingestion.
     """
-    _set_level(logging.INFO)
+    _set_level(logging.DEBUG)
 
 
 def _set_level(level: int) -> None:
@@ -34,3 +35,18 @@ def _set_level(level: int) -> None:
     # twice.
     if not logger.hasHandlers():
         logger.addHandler(logging.StreamHandler())
+
+
+def log_io(info_message: Union[str, None], debug_message: str) -> None:
+    """
+    Data-ingesti timeframes range widely, from seconds to the better part of an hour.  Some folks
+    won't want details in the former; some will want details in the latter.  For I/O and for I/O
+    only, it's helpfulto print a short message at INFO level, or a different, longer message
+    at/beyond DEBUG level.
+    """
+    if logger.level == logging.INFO:
+        if info_message is not None:
+            logger.info(info_message)
+    elif logger.level <= logging.DEBUG:
+        if debug_message is not None:
+            logger.debug(debug_message)

--- a/apis/python/src/tiledbsc/logging.py
+++ b/apis/python/src/tiledbsc/logging.py
@@ -3,19 +3,34 @@ import logging
 logger = logging.getLogger("tiledbsc")
 
 
-def info():
-    """
-    Sets tiledbsc logging to an INFO level. Use `tiledbsc.logging.info()` in notebooks to see
-    progress indicators for data ingestion.
-    """
-    logger.setLevel(logging.INFO)
-    logger.addHandler(logging.StreamHandler())
-
-
 def warning():
     """
     Sets tiledbsc logging to a WARNING level. Use `tiledbsc.logging.info()` in notebooks to suppress
     progress indicators for data ingestion.
     """
-    logger.setLevel(logging.WARNING)
-    logger.addHandler(logging.StreamHandler())
+    _set_level(logging.WARNING)
+
+
+def info():
+    """
+    Sets tiledbsc logging to an INFO level. Use `tiledbsc.logging.info()` in notebooks to see
+    progress indicators for data ingestion.
+    """
+    _set_level(logging.INFO)
+
+
+def debug():
+    """
+    Sets tiledbsc logging to an DEBUG level. Use `tiledbsc.logging.debug()` in notebooks to see more
+    detailed progress indicators for data ingestion.
+    """
+    _set_level(logging.INFO)
+
+
+def _set_level(level: int) -> None:
+    logger.setLevel(level)
+    # Without this check, if someone does `tiledbsc.logging.info()` twice, or
+    # `tiledbsc.logging.info()` then `tiledbsc.logging.debug()`, etc., then log messages will appear
+    # twice.
+    if not logger.hasHandlers():
+        logger.addHandler(logging.StreamHandler())

--- a/apis/python/src/tiledbsc/raw_group.py
+++ b/apis/python/src/tiledbsc/raw_group.py
@@ -8,7 +8,7 @@ from .annotation_dataframe import AnnotationDataFrame
 from .annotation_matrix_group import AnnotationMatrixGroup
 from .annotation_pairwise_matrix_group import AnnotationPairwiseMatrixGroup
 from .assay_matrix_group import AssayMatrixGroup
-from .logging import logger
+from .logging import log_io
 from .tiledb_group import TileDBGroup
 
 
@@ -68,7 +68,7 @@ class RawGroup(TileDBGroup):
         Writes `anndata.raw` to a TileDB group structure.
         """
         s = util.get_start_stamp()
-        logger.info(f"{self._indent}START  WRITING {self.uri}")
+        log_io(None, f"{self._indent}START  WRITING {self.uri}")
 
         # Must be done first, to create the parent directory
         self.create_unless_exists()
@@ -91,7 +91,7 @@ class RawGroup(TileDBGroup):
             )
         self._add_object(self.varm)
 
-        logger.info(util.format_elapsed(s, f"{self._indent}FINISH WRITING {self.uri}"))
+        log_io(None, util.format_elapsed(s, f"{self._indent}FINISH WRITING {self.uri}"))
 
     # ----------------------------------------------------------------
     def to_anndata_raw(self, obs_labels):

--- a/apis/python/src/tiledbsc/tiledb_group.py
+++ b/apis/python/src/tiledbsc/tiledb_group.py
@@ -58,7 +58,7 @@ class TileDBGroup(TileDBObject):
         """
         Creates the TileDB group data structure on disk/S3/cloud.
         """
-        logger.info(f"{self._indent}Creating TileDB group {self.uri}")
+        logger.debug(f"{self._indent}Creating TileDB group {self.uri}")
         tiledb.group_create(uri=self.uri, ctx=self._ctx)
 
         self._set_object_type_metadata()

--- a/apis/python/src/tiledbsc/uns_array.py
+++ b/apis/python/src/tiledbsc/uns_array.py
@@ -7,7 +7,7 @@ import tiledb
 
 import tiledbsc.util as util
 
-from .logging import logger
+from .logging import log_io
 from .tiledb_array import TileDBArray
 from .tiledb_group import TileDBGroup
 
@@ -37,7 +37,7 @@ class UnsArray(TileDBArray):
         """
 
         s = util.get_start_stamp()
-        logger.info(f"{self._indent}START  WRITING PANDAS.DATAFRAME {self.uri}")
+        log_io(None, f"{self._indent}START  WRITING PANDAS.DATAFRAME {self.uri}")
 
         tiledb.from_pandas(
             uri=self.uri,
@@ -47,10 +47,11 @@ class UnsArray(TileDBArray):
             ctx=self._ctx,
         )
 
-        logger.info(
+        log_io(
+            None,
             util.format_elapsed(
                 s, f"{self._indent}FINISH WRITING PANDAS.DATAFRAME {self.uri}"
-            )
+            ),
         )
 
     # ----------------------------------------------------------------
@@ -88,7 +89,7 @@ class UnsArray(TileDBArray):
         """
 
         s = util.get_start_stamp()
-        logger.info(f"{self._indent}START  WRITING FROM NUMPY.NDARRAY {self.uri}")
+        log_io(None, f"{self._indent}START  WRITING FROM NUMPY.NDARRAY {self.uri}")
 
         if "numpy" in str(type(arr)) and str(arr.dtype).startswith("<U"):
             # Note arr.astype('str') does not lead to a successfuly tiledb.from_numpy.
@@ -97,15 +98,16 @@ class UnsArray(TileDBArray):
         # overwrite = False
         # if self.exists:
         #     overwrite = True
-        #     logger.info(f"{self._indent}Re-using existing array {self.uri}")
+        #     log_io(None, f"{self._indent}Re-using existing array {self.uri}")
         # tiledb.from_numpy(uri=self.uri, array=arr, ctx=self._ctx, overwrite=overwrite)
         # TODO: find the right syntax for update-in-place (tiledb.from_pandas uses `mode`)
         tiledb.from_numpy(uri=self.uri, array=arr, ctx=self._ctx)
 
-        logger.info(
+        log_io(
+            None,
             util.format_elapsed(
                 s, f"{self._indent}FINISH WRITING FROM NUMPY.NDARRAY {self.uri}"
-            )
+            ),
         )
 
     # ----------------------------------------------------------------
@@ -117,20 +119,21 @@ class UnsArray(TileDBArray):
         """
 
         s = util.get_start_stamp()
-        logger.info(f"{self._indent}START  WRITING FROM SCIPY.SPARSE.CSR {self.uri}")
+        log_io(None, f"{self._indent}START  WRITING FROM SCIPY.SPARSE.CSR {self.uri}")
 
         nrows, ncols = csr.shape
         if self.exists():
-            logger.info(f"{self._indent}Re-using existing array {self.uri}")
+            log_io(None, f"{self._indent}Re-using existing array {self.uri}")
         else:
             self.create_empty_array_for_csr("data", csr.dtype, nrows, ncols)
 
         self.ingest_data_from_csr(csr)
 
-        logger.info(
+        log_io(
+            None,
             util.format_elapsed(
                 s, f"{self._indent}FINISH WRITING FROM SCIPY.SPARSE.CSR {self.uri}"
-            )
+            ),
         )
 
     # ----------------------------------------------------------------

--- a/apis/python/src/tiledbsc/uns_group.py
+++ b/apis/python/src/tiledbsc/uns_group.py
@@ -11,7 +11,7 @@ import tiledb
 
 import tiledbsc.util as util
 
-from .logging import logger
+from .logging import log_io, logger
 from .tiledb_group import TileDBGroup
 from .uns_array import UnsArray
 
@@ -145,7 +145,7 @@ class UnsGroup(TileDBGroup):
         """
 
         s = util.get_start_stamp()
-        logger.info(f"{self._indent}START  WRITING {self.uri}")
+        log_io(None, f"{self._indent}START  WRITING {self.uri}")
 
         # Must be done first, to create the parent directory
         self.create_unless_exists()
@@ -171,7 +171,9 @@ class UnsGroup(TileDBGroup):
                 # support nested cells, AKA "list" type.
                 #
                 # This could, however, be converted to a dataframe and ingested that way.
-                logger.info(f"{self._indent}Skipping structured array: {component_uri}")
+                log_io(
+                    None, f"{self._indent}Skipping structured array: {component_uri}"
+                )
                 continue
 
             if isinstance(value, Mapping):
@@ -210,13 +212,14 @@ class UnsGroup(TileDBGroup):
                 self._add_object(array)
 
             else:
-                logger.info(
-                    f"{self._indent}Skipping unrecognized type:",
-                    component_uri,
-                    type(value),
+                logger.error(
+                    f"{self._indent}Skipping unrecognized type: {component_uri} {type(value)}",
                 )
 
-        logger.info(util.format_elapsed(s, f"{self._indent}FINISH WRITING {self.uri}"))
+        log_io(
+            os.path.basename(self.uri),
+            util.format_elapsed(s, f"{self._indent}FINISH WRITING {self.uri}"),
+        )
 
     # ----------------------------------------------------------------
     def to_dict_of_matrices(self) -> Dict:
@@ -224,11 +227,14 @@ class UnsGroup(TileDBGroup):
         Reads the recursive group/array uns data from TileDB storage and returns them as a recursive dict of matrices.
         """
         if not self.exists():
-            logger.info(f"{self._indent}{self.uri} not found")
+            log_io(
+                f"{self._indent}{self.uri} not found",
+                f"{self._indent}{self.uri} not found",
+            )
             return {}
 
         s = util.get_start_stamp()
-        logger.info(f"{self._indent}START  read {self.uri}")
+        log_io(None, f"{self._indent}START  read {self.uri}")
 
         with self._open() as G:
             retval = {}
@@ -248,6 +254,9 @@ class UnsGroup(TileDBGroup):
                         f"Internal error: found uns group element neither group nor array: type is {str(element.type)}"
                     )
 
-        logger.info(util.format_elapsed(s, f"{self._indent}FINISH read {self.uri}"))
+        log_io(
+            os.path.basename(self.uri),
+            util.format_elapsed(s, f"{self._indent}FINISH WRITING {self.uri}"),
+        )
 
         return retval

--- a/apis/python/tools/ingestor
+++ b/apis/python/tools/ingestor
@@ -14,7 +14,6 @@ URIs will be supported.
 """
 
 import argparse
-import logging
 import os
 import shutil
 import sys
@@ -25,8 +24,6 @@ import tiledbsc
 import tiledbsc.io
 import tiledbsc.util
 
-logger = logging.getLogger("tiledbsc")
-
 
 # ================================================================
 def main():
@@ -35,6 +32,9 @@ def main():
     )
     parser.add_argument(
         "-q", "--quiet", help="decrease output verbosity", action="store_true"
+    )
+    parser.add_argument(
+        "--debug", help="increase output verbosity", action="store_true"
     )
     parser.add_argument(
         "-n",
@@ -97,8 +97,9 @@ select `relative=True`. (This is the default.)
             args.ifexists = ["continue"]
 
     write_soco = args.soco
-    verbose = not args.quiet
-    if verbose:
+    if args.debug:
+        tiledbsc.logging.debug()
+    elif not args.quiet:
         tiledbsc.logging.info()
 
     if args.relative is None:
@@ -189,7 +190,7 @@ def ingest_one(
     vfs = tiledb.VFS()
     if not vfs.is_file(input_path):
         # Print this neatly and exit neatly, to avoid a multi-line stack trace otherwise.
-        logging.error(f"Input path not found: {input_path}")
+        tiledbsc.logging.logger.error(f"Input path not found: {input_path}")
         sys.exit(1)
 
     # Prepare to write the output.
@@ -212,10 +213,12 @@ def ingest_one(
     else:
         if os.path.exists(output_path):
             if ifexists == "continue":
-                logger.info(f"Already exists; continuing: {output_path}")
+                tiledbsc.logging.logger.info(
+                    f"Already exists; continuing: {output_path}"
+                )
                 return
             elif ifexists == "abort":
-                logging.error(f"Already exists; aborting: {output_path}")
+                tiledbsc.logging.error(f"Already exists; aborting: {output_path}")
                 sys.exit(1)
             elif ifexists == "replace":
                 if output_path.startswith("s3://") or output_path.startswith(
@@ -224,7 +227,9 @@ def ingest_one(
                     raise Exception(
                         "--ifexists replace currently only is compatible with local-disk paths"
                     )
-                print(f"Already exists; replacing: {output_path}")
+                tiledbsc.logging.logger.info(
+                    f"Already exists; replacing: {output_path}"
+                )
                 shutil.rmtree(output_path)  # Overwrite
             else:
                 raise Exception(
@@ -233,7 +238,7 @@ def ingest_one(
         # Do the ingest into TileDB.
         tiledbsc.io.from_h5ad(soma, input_path)
 
-    logger.info(f"Wrote {output_path}")
+    tiledbsc.logging.logger.info(f"Wrote {output_path}")
 
     if write_soco:
         soco = tiledbsc.SOMACollection(soco_dir, soma_options=soma_options)
@@ -242,8 +247,10 @@ def ingest_one(
             raise Exception(f"Could not create SOCO at {soco.uri}")
         soco.add(soma)
 
-        logger.info("")
-        logger.info(f"Added SOMA {soma.name} to SOMACollection {soco_dir}")
+        tiledbsc.logging.logger.info("")
+        tiledbsc.logging.logger.info(
+            f"Added SOMA {soma.name} to SOMACollection {soco_dir}"
+        )
 
 
 # ================================================================


### PR DESCRIPTION
Logging ingests is crucial -- while some intro datasets take a few seconds to upload, gigascale data takes more time. During this time it's essential to give the user something to see, some indication that something is happen.

Before this PR, the log levels were silent, or verbose. During notebook/doc work this week I found the latter was taking up more than a full screen in notebook views -- which is overkill.

On this PR we strike a middle ground: `info` level gives a brief summary, with something every so often for the time-consuming bits (if any), but minimalistic in character-count. The old verbosity is still available using `tiledbsc.logging.debug()`.

Before-and-afters using `tiledbsc.logging.info()` in a notebook:

<img width="1402" alt="Screen Shot 2022-07-01 at 4 27 10 PM" src="https://user-images.githubusercontent.com/2008794/176964019-d3fc9af0-b36d-43a3-a0fe-9d2707707ebf.png">

