### PR TITLE
Depend on TileDB-Py 0.16.2

### DIFF
--- a/apis/python/setup.cfg
+++ b/apis/python/setup.cfg
@@ -30,7 +30,7 @@ packges = tiledbsc
 platforms = any
 zip_safe = False
 install_requires =
-    tiledb>=0.16.1
+    tiledb>=0.16.2
     scipy
     pandas
     pyarrow


### PR DESCRIPTION
Brings in https://github.com/TileDB-Inc/TileDB-Py/releases/tag/0.16.2 which in turns brings in core https://github.com/TileDB-Inc/TileDB/releases/tag/2.10.2 which is a bugfix release.