### PR TITLE
Correctly support element deletion in TileDB Cloud

### DIFF
--- a/apis/python/src/tiledbsc/tiledb_group.py
+++ b/apis/python/src/tiledbsc/tiledb_group.py
@@ -153,12 +153,19 @@ class TileDBGroup(TileDBObject):
         obj.uri = self._get_child_uri(obj.name)
 
     def _remove_object(self, obj: TileDBObject) -> None:
-        with self._open("w") as G:
-            G.remove(obj.name)
+        self._remove_object_by_name(obj.name)
 
     def _remove_object_by_name(self, member_name: str) -> None:
-        with self._open("w") as G:
-            G.remove(member_name)
+        if self.uri.startswith("tiledb://"):
+            mapping = self._get_member_names_to_uris()
+            if member_name not in mapping:
+                raise Exception(f"name {member_name} not present in group {self.uri}")
+            member_uri = mapping[member_name]
+            with self._open("w") as G:
+                G.remove(member_uri)
+        else:
+            with self._open("w") as G:
+                G.remove(member_name)
 
     def _get_member_names(self) -> Sequence[str]:
         """


### PR DESCRIPTION
Found during today's notebook work.

Element deletion was working fine for local disk and S3, but not for TileDB Cloud; as of this PR it works for all three.

Note that we (intentionally) don't have tiledb-cloud unit-test cases in this repo -- although there are many local-disk cases. Nonetheless for the record here is a scenario:

```
>>> import tiledbsc

>>> soco = tiledbsc.SOMACollection('tiledb://johnkerl-tiledb/s3://tiledb-johnkerl/scratch/soco123')
>>> soma1 = tiledbsc.SOMA('tiledb://johnkerl-tiledb/pbmc3k_processed')
>>> soma2 = tiledbsc.SOMA('tiledb://johnkerl-tiledb/pbmc-small')
>>> soco.add(soma1)
>>> soco.add(soma2)

>>> soco.keys()
['pbmc3k_processed', 'pbmc-small']

>>> soco.remove(soma1)

>>> soco.keys()
['pbmc-small']

>>> del soco['pbmc-small']
>>> soco.keys()
[]
```