### PR TITLE
Optimize constructor time for tiledb-cloud case

### DIFF
--- a/apis/python/src/tiledbsc/raw_group.py
+++ b/apis/python/src/tiledbsc/raw_group.py
@@ -35,18 +35,12 @@ class RawGroup(TileDBGroup):
         super().__init__(uri=uri, name=name, parent=parent)
         self.parent_obs = obs
 
-        # TODO: COMMENT
-        member_names = ["X", "var", "varm", "varp"]
-        child_uris = self._get_child_uris(member_names)  # See comments in that function
+        # See comments in _get_child_uris
+        child_uris = self._get_child_uris(["X", "var", "varm", "varp"])
 
-        X_uri = child_uris["X"]  # See comments in that function
-        var_uri = child_uris["var"]
-        varm_uri = child_uris["varm"]
-        varp_uri = child_uris["varp"]
-
-        self.var = AnnotationDataFrame(uri=var_uri, name="var", parent=self)
+        self.var = AnnotationDataFrame(uri=child_uris["var"], name="var", parent=self)
         self.X = AssayMatrixGroup(
-            uri=X_uri,
+            uri=child_uris["X"],
             name="X",
             row_dim_name="obs_id",
             col_dim_name="var_id",
@@ -54,9 +48,11 @@ class RawGroup(TileDBGroup):
             col_dataframe=self.var,
             parent=self,
         )
-        self.varm = AnnotationMatrixGroup(uri=varm_uri, name="varm", parent=self)
+        self.varm = AnnotationMatrixGroup(
+            uri=child_uris["varm"], name="varm", parent=self
+        )
         self.varp = AnnotationPairwiseMatrixGroup(
-            uri=varp_uri,
+            uri=child_uris["varp"],
             name="varp",
             row_dataframe=self.var,
             col_dataframe=self.var,

--- a/apis/python/src/tiledbsc/raw_group.py
+++ b/apis/python/src/tiledbsc/raw_group.py
@@ -35,10 +35,14 @@ class RawGroup(TileDBGroup):
         super().__init__(uri=uri, name=name, parent=parent)
         self.parent_obs = obs
 
-        X_uri = self._get_child_uri("X")  # See comments in that function
-        var_uri = self._get_child_uri("var")
-        varm_uri = self._get_child_uri("varm")
-        varp_uri = self._get_child_uri("varp")
+        # TODO: COMMENT
+        member_names = ["X", "var", "varm", "varp"]
+        child_uris = self._get_child_uris(member_names)  # See comments in that function
+
+        X_uri = child_uris["X"]  # See comments in that function
+        var_uri = child_uris["var"]
+        varm_uri = child_uris["varm"]
+        varp_uri = child_uris["varp"]
 
         self.var = AnnotationDataFrame(uri=var_uri, name="var", parent=self)
         self.X = AssayMatrixGroup(

--- a/apis/python/src/tiledbsc/soma.py
+++ b/apis/python/src/tiledbsc/soma.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import os
 from collections import Counter
 from typing import Optional, Sequence
+import time
 
 import pandas as pd
 import tiledb
@@ -59,6 +60,9 @@ class SOMA(TileDBGroup):
         :param uri: URI of the TileDB group
         """
 
+        t1 = time.time()
+
+        print(time.time(), "AAA001")
         # People can (and should) call by name. However, it's easy to forget. For example,
         # if someone does 'tiledbsc.SOMA("myuri", ctx)' instead of 'tiledbsc.SOMA("myury", ctx)',
         # behavior will not be what they expect, and we should let them know sooner than later.
@@ -72,6 +76,7 @@ class SOMA(TileDBGroup):
             assert isinstance(ctx, tiledb.Ctx)
         if parent is not None:
             assert isinstance(parent, TileDBGroup)
+        print(time.time(), "AAA002")
 
         if ctx is None and config is not None:
             ctx = tiledb.Ctx(config)
@@ -81,6 +86,7 @@ class SOMA(TileDBGroup):
             name = os.path.basename(uri.rstrip("/"))
             if name == "":
                 name = "soma"
+        print(time.time(), "AAA003")
         super().__init__(
             uri=uri,
             name=name,
@@ -89,18 +95,44 @@ class SOMA(TileDBGroup):
             ctx=ctx,
         )
 
-        obs_uri = self._get_child_uri("obs")  # See comments in that function
-        var_uri = self._get_child_uri("var")
-        X_uri = self._get_child_uri("X")
-        obsm_uri = self._get_child_uri("obsm")
-        varm_uri = self._get_child_uri("varm")
-        obsp_uri = self._get_child_uri("obsp")
-        varp_uri = self._get_child_uri("varp")
-        raw_uri = self._get_child_uri("raw")
-        uns_uri = self._get_child_uri("uns")
+        # t01 = time.time()
+        # print(time.time(), "AAA004")
+        # obs_uri = self._get_child_uri("obs")  # See comments in that function
+        # var_uri = self._get_child_uri("var")
+        # X_uri = self._get_child_uri("X")
+        # obsm_uri = self._get_child_uri("obsm")
+        # varm_uri = self._get_child_uri("varm")
+        # obsp_uri = self._get_child_uri("obsp")
+        # varp_uri = self._get_child_uri("varp")
+        # raw_uri = self._get_child_uri("raw")
+        # uns_uri = self._get_child_uri("uns")
+        # t02 = time.time()
+        # print("BBB001 %.3f" % (t02-t01))
 
+        t01 = time.time()
+        print(time.time(), "AAA104")
+
+        member_names = ["obs", "var", "X", "obsm", "varm", "obsp", "varp", "raw", "uns"]
+        child_uris = self._get_child_uris(member_names)  # See comments in that function
+
+        obs_uri = child_uris["obs"]
+        var_uri = child_uris["var"]
+        X_uri = child_uris["X"]
+        obsm_uri = child_uris["obsm"]
+        varm_uri = child_uris["varm"]
+        obsp_uri = child_uris["obsp"]
+        varp_uri = child_uris["varp"]
+        raw_uri = child_uris["raw"]
+        uns_uri = child_uris["uns"]
+
+        t02 = time.time()
+        print("BBB001 %.3f" % (t02-t01))
+
+        print(time.time(), "AAA005")
         self.obs = AnnotationDataFrame(uri=obs_uri, name="obs", parent=self)
+        print(time.time(), "AAA006")
         self.var = AnnotationDataFrame(uri=var_uri, name="var", parent=self)
+        print(time.time(), "AAA007")
         self.X = AssayMatrixGroup(
             uri=X_uri,
             name="X",
@@ -110,8 +142,11 @@ class SOMA(TileDBGroup):
             col_dataframe=self.var,
             parent=self,
         )
+        print(time.time(), "AAA008")
         self.obsm = AnnotationMatrixGroup(uri=obsm_uri, name="obsm", parent=self)
+        print(time.time(), "AAA009")
         self.varm = AnnotationMatrixGroup(uri=varm_uri, name="varm", parent=self)
+        print(time.time(), "AAA010")
         self.obsp = AnnotationPairwiseMatrixGroup(
             uri=obsp_uri,
             name="obsp",
@@ -119,6 +154,7 @@ class SOMA(TileDBGroup):
             col_dataframe=self.obs,
             parent=self,
         )
+        print(time.time(), "AAA011")
         self.varp = AnnotationPairwiseMatrixGroup(
             uri=varp_uri,
             name="varp",
@@ -126,7 +162,9 @@ class SOMA(TileDBGroup):
             col_dataframe=self.var,
             parent=self,
         )
+        print(time.time(), "AAA012")
         self.raw = RawGroup(uri=raw_uri, name="raw", obs=self.obs, parent=self)
+        print(time.time(), "AAA013")
         self.uns = UnsGroup(uri=uns_uri, name="uns", parent=self)
 
         # If URI is "/something/test1" then:
@@ -138,6 +176,9 @@ class SOMA(TileDBGroup):
         # * obs_uri  is "tiledb://namespace/s3://bucketname/something/test1/obs"
         # * var_uri  is "tiledb://namespace/s3://bucketname/something/test1/var"
         # * data_uri is "tiledb://namespace/s3://bucketname/something/test1/X"
+
+        t2 = time.time()
+        print("SOMA CTOR SECONDS %.3f" % (t2-t1))
 
     # ----------------------------------------------------------------
     def __repr__(self) -> str:

--- a/apis/python/src/tiledbsc/soma.py
+++ b/apis/python/src/tiledbsc/soma.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import os
 from collections import Counter
 from typing import Optional, Sequence
-import time
 
 import pandas as pd
 import tiledb
@@ -60,9 +59,6 @@ class SOMA(TileDBGroup):
         :param uri: URI of the TileDB group
         """
 
-        t1 = time.time()
-
-        print(time.time(), "AAA001")
         # People can (and should) call by name. However, it's easy to forget. For example,
         # if someone does 'tiledbsc.SOMA("myuri", ctx)' instead of 'tiledbsc.SOMA("myury", ctx)',
         # behavior will not be what they expect, and we should let them know sooner than later.
@@ -76,7 +72,6 @@ class SOMA(TileDBGroup):
             assert isinstance(ctx, tiledb.Ctx)
         if parent is not None:
             assert isinstance(parent, TileDBGroup)
-        print(time.time(), "AAA002")
 
         if ctx is None and config is not None:
             ctx = tiledb.Ctx(config)
@@ -86,7 +81,6 @@ class SOMA(TileDBGroup):
             name = os.path.basename(uri.rstrip("/"))
             if name == "":
                 name = "soma"
-        print(time.time(), "AAA003")
         super().__init__(
             uri=uri,
             name=name,
@@ -95,8 +89,6 @@ class SOMA(TileDBGroup):
             ctx=ctx,
         )
 
-        # t01 = time.time()
-        # print(time.time(), "AAA004")
         # obs_uri = self._get_child_uri("obs")  # See comments in that function
         # var_uri = self._get_child_uri("var")
         # X_uri = self._get_child_uri("X")
@@ -106,11 +98,6 @@ class SOMA(TileDBGroup):
         # varp_uri = self._get_child_uri("varp")
         # raw_uri = self._get_child_uri("raw")
         # uns_uri = self._get_child_uri("uns")
-        # t02 = time.time()
-        # print("BBB001 %.3f" % (t02-t01))
-
-        t01 = time.time()
-        print(time.time(), "AAA104")
 
         member_names = ["obs", "var", "X", "obsm", "varm", "obsp", "varp", "raw", "uns"]
         child_uris = self._get_child_uris(member_names)  # See comments in that function
@@ -125,14 +112,8 @@ class SOMA(TileDBGroup):
         raw_uri = child_uris["raw"]
         uns_uri = child_uris["uns"]
 
-        t02 = time.time()
-        print("BBB001 %.3f" % (t02-t01))
-
-        print(time.time(), "AAA005")
         self.obs = AnnotationDataFrame(uri=obs_uri, name="obs", parent=self)
-        print(time.time(), "AAA006")
         self.var = AnnotationDataFrame(uri=var_uri, name="var", parent=self)
-        print(time.time(), "AAA007")
         self.X = AssayMatrixGroup(
             uri=X_uri,
             name="X",
@@ -142,11 +123,8 @@ class SOMA(TileDBGroup):
             col_dataframe=self.var,
             parent=self,
         )
-        print(time.time(), "AAA008")
         self.obsm = AnnotationMatrixGroup(uri=obsm_uri, name="obsm", parent=self)
-        print(time.time(), "AAA009")
         self.varm = AnnotationMatrixGroup(uri=varm_uri, name="varm", parent=self)
-        print(time.time(), "AAA010")
         self.obsp = AnnotationPairwiseMatrixGroup(
             uri=obsp_uri,
             name="obsp",
@@ -154,7 +132,6 @@ class SOMA(TileDBGroup):
             col_dataframe=self.obs,
             parent=self,
         )
-        print(time.time(), "AAA011")
         self.varp = AnnotationPairwiseMatrixGroup(
             uri=varp_uri,
             name="varp",
@@ -162,9 +139,7 @@ class SOMA(TileDBGroup):
             col_dataframe=self.var,
             parent=self,
         )
-        print(time.time(), "AAA012")
         self.raw = RawGroup(uri=raw_uri, name="raw", obs=self.obs, parent=self)
-        print(time.time(), "AAA013")
         self.uns = UnsGroup(uri=uns_uri, name="uns", parent=self)
 
         # If URI is "/something/test1" then:
@@ -176,9 +151,6 @@ class SOMA(TileDBGroup):
         # * obs_uri  is "tiledb://namespace/s3://bucketname/something/test1/obs"
         # * var_uri  is "tiledb://namespace/s3://bucketname/something/test1/var"
         # * data_uri is "tiledb://namespace/s3://bucketname/something/test1/X"
-
-        t2 = time.time()
-        print("SOMA CTOR SECONDS %.3f" % (t2-t1))
 
     # ----------------------------------------------------------------
     def __repr__(self) -> str:

--- a/apis/python/src/tiledbsc/soma.py
+++ b/apis/python/src/tiledbsc/soma.py
@@ -89,16 +89,7 @@ class SOMA(TileDBGroup):
             ctx=ctx,
         )
 
-        # obs_uri = self._get_child_uri("obs")  # See comments in that function
-        # var_uri = self._get_child_uri("var")
-        # X_uri = self._get_child_uri("X")
-        # obsm_uri = self._get_child_uri("obsm")
-        # varm_uri = self._get_child_uri("varm")
-        # obsp_uri = self._get_child_uri("obsp")
-        # varp_uri = self._get_child_uri("varp")
-        # raw_uri = self._get_child_uri("raw")
-        # uns_uri = self._get_child_uri("uns")
-
+        # TODO: COMMENT
         member_names = ["obs", "var", "X", "obsm", "varm", "obsp", "varp", "raw", "uns"]
         child_uris = self._get_child_uris(member_names)  # See comments in that function
 

--- a/apis/python/src/tiledbsc/soma.py
+++ b/apis/python/src/tiledbsc/soma.py
@@ -89,9 +89,10 @@ class SOMA(TileDBGroup):
             ctx=ctx,
         )
 
-        # TODO: COMMENT
-        member_names = ["obs", "var", "X", "obsm", "varm", "obsp", "varp", "raw", "uns"]
-        child_uris = self._get_child_uris(member_names)  # See comments in that function
+        # See comments in _get_child_uris
+        child_uris = self._get_child_uris(
+            ["obs", "var", "X", "obsm", "varm", "obsp", "varp", "raw", "uns"]
+        )
 
         obs_uri = child_uris["obs"]
         var_uri = child_uris["var"]
@@ -133,15 +134,12 @@ class SOMA(TileDBGroup):
         self.raw = RawGroup(uri=raw_uri, name="raw", obs=self.obs, parent=self)
         self.uns = UnsGroup(uri=uns_uri, name="uns", parent=self)
 
-        # If URI is "/something/test1" then:
-        # * obs_uri  is "/something/test1/obs"
-        # * var_uri  is "/something/test1/var"
-        # * data_uri is "/something/test1/X"
-
-        # If URI is "tiledb://namespace/s3://bucketname/something/test1" then:
-        # * obs_uri  is "tiledb://namespace/s3://bucketname/something/test1/obs"
-        # * var_uri  is "tiledb://namespace/s3://bucketname/something/test1/var"
-        # * data_uri is "tiledb://namespace/s3://bucketname/something/test1/X"
+        # Sample SOMA/member URIs:
+        #
+        # SOMA                             member
+        # "/foo/test1"                     "/foo/test1/obs"
+        # "tiledb://ns/s3://bkt/foo/test1" "tiledb://ns/s3://bkt/foo/test1/obs"
+        # "tiledb://ns/test1"              "tiledb://ns/95cb11b5-2052-461b-9b99-cfa94e51e23f"
 
     # ----------------------------------------------------------------
     def __repr__(self) -> str:

--- a/apis/python/src/tiledbsc/soma_collection.py
+++ b/apis/python/src/tiledbsc/soma_collection.py
@@ -132,7 +132,6 @@ class SOMACollection(TileDBGroup):
                 self._somas[name] = SOMA(uri=uri, name=name, parent=self, ctx=self._ctx)
             yield self._somas[name]
 
-
     # ----------------------------------------------------------------
     def __contains__(self, name: str) -> bool:
         """

--- a/apis/python/src/tiledbsc/soma_collection.py
+++ b/apis/python/src/tiledbsc/soma_collection.py
@@ -61,7 +61,7 @@ class SOMACollection(TileDBGroup):
             ctx=ctx,
         )
 
-        self._somas = None
+        self._somas = {}
 
     # ----------------------------------------------------------------
     def __repr__(self) -> str:
@@ -125,8 +125,6 @@ class SOMACollection(TileDBGroup):
         """
         Implements `for soma in soco: ...`
         """
-        if self._somas is None:
-            self._somas = {}
         for name, uri in self._get_member_names_to_uris().items():
             if name not in self._somas:
                 self._somas[name] = SOMA(uri=uri, name=name, parent=self, ctx=self._ctx)

--- a/apis/python/src/tiledbsc/soma_collection.py
+++ b/apis/python/src/tiledbsc/soma_collection.py
@@ -14,7 +14,10 @@ class SOMACollection(TileDBGroup):
     Implements a collection of `SOMA` objects.
     """
 
-    # XXX COMMENT
+    # This is a cache to avoid the overhead of calling the SOMA constructor repeatedly.  That
+    # constructor isn't particuarly expensive, except that for tiledb-cloud URIs it needs to
+    # interrogate the server repeatedly for recursive group-member URIs, which has web-request
+    # latency.
     _somas: Dict[str, SOMA]
 
     # ----------------------------------------------------------------
@@ -127,6 +130,7 @@ class SOMACollection(TileDBGroup):
         """
         for name, uri in self._get_member_names_to_uris().items():
             if name not in self._somas:
+                # SOMA-constructor cache
                 self._somas[name] = SOMA(uri=uri, name=name, parent=self, ctx=self._ctx)
             yield self._somas[name]
 
@@ -160,6 +164,7 @@ class SOMACollection(TileDBGroup):
         member exists.  Overloads the `[...]` operator.
         """
         if name in self._somas:
+            # SOMA-constructor cache
             return self._somas[name]
 
         with self._open("r") as G:

--- a/apis/python/src/tiledbsc/soma_collection.py
+++ b/apis/python/src/tiledbsc/soma_collection.py
@@ -162,6 +162,9 @@ class SOMACollection(TileDBGroup):
         Returns a `SOMA` element at the given name within the group, or `None` if no such
         member exists.  Overloads the `[...]` operator.
         """
+        if name in self._somas:
+            return self._somas[name]
+
         with self._open("r") as G:
             try:
                 obj = G[name]  # This returns a tiledb.object.Object.

--- a/apis/python/src/tiledbsc/soma_collection.py
+++ b/apis/python/src/tiledbsc/soma_collection.py
@@ -1,4 +1,4 @@
-from typing import Iterator, Optional, Sequence, Set, Union
+from typing import Dict, Iterator, Optional, Sequence, Set, Union
 
 import tiledb
 
@@ -13,6 +13,9 @@ class SOMACollection(TileDBGroup):
     """
     Implements a collection of `SOMA` objects.
     """
+
+    # XXX COMMENT
+    _somas: Dict[str, SOMA]
 
     # ----------------------------------------------------------------
     def __init__(
@@ -57,6 +60,8 @@ class SOMACollection(TileDBGroup):
             soma_options=soma_options,
             ctx=ctx,
         )
+
+        self._somas = None
 
     # ----------------------------------------------------------------
     def __repr__(self) -> str:
@@ -120,8 +125,13 @@ class SOMACollection(TileDBGroup):
         """
         Implements `for soma in soco: ...`
         """
+        if self._somas is None:
+            self._somas = {}
         for name, uri in self._get_member_names_to_uris().items():
-            yield SOMA(uri=uri, name=name, parent=self, ctx=self._ctx)
+            if name not in self._somas:
+                self._somas[name] = SOMA(uri=uri, name=name, parent=self, ctx=self._ctx)
+            yield self._somas[name]
+
 
     # ----------------------------------------------------------------
     def __contains__(self, name: str) -> bool:

--- a/apis/python/src/tiledbsc/tiledb_group.py
+++ b/apis/python/src/tiledbsc/tiledb_group.py
@@ -15,7 +15,6 @@ class TileDBGroup(TileDBObject):
     Wraps groups from TileDB-Py by retaining a URI, options, etc.
     """
 
-    _cached_exists: Optional[bool]
     _cached_member_names_to_uris: Optional[Dict[str, str]]
 
     def __init__(
@@ -33,7 +32,6 @@ class TileDBGroup(TileDBObject):
         See the TileDBObject constructor.
         """
         super().__init__(uri, name, parent=parent, soma_options=soma_options, ctx=ctx)
-        self._cached_exists = None
         self._cached_member_names_to_uris = None
 
     def exists(self) -> bool:
@@ -43,11 +41,8 @@ class TileDBGroup(TileDBObject):
         SOMA has been populated but doesn't have this member (e.g. not all SOMAs have a `varp`).
         """
         # TODO: NOTE WHAT IF VFS.DELETE AFTER INSTANTIATION
-        if self._cached_exists is None:
-            self._cached_exists = bool(
-                tiledb.object_type(self.uri, ctx=self._ctx) == "group"
-            )
-        return self._cached_exists
+        # TODO: NON-CACHEABLE AND WHY
+        return tiledb.object_type(self.uri, ctx=self._ctx) == "group"
 
     def create_unless_exists(self) -> None:
         """
@@ -89,7 +84,6 @@ class TileDBGroup(TileDBObject):
         This is just a convenience wrapper around tiledb group-open.
         It works asa `with self._open() as G:` as well as `G = self._open(); ...; G.close()`.
         """
-        print("OPEN", self.uri)
         assert mode in ("r", "w")
         if mode == "r" and not self.exists():
             raise Exception(f"Does not exist: {self.uri}")
@@ -236,7 +230,6 @@ class TileDBGroup(TileDBObject):
         if self._cached_member_names_to_uris is None:
             with self._open("r") as G:
                 self._cached_member_names_to_uris = {obj.name: obj.uri for obj in G}
-                print("GMN2U", self.uri)
         return self._cached_member_names_to_uris
 
     def show_metadata(self, recursively: bool = True, indent: str = "") -> None:

--- a/apis/python/src/tiledbsc/tiledb_group.py
+++ b/apis/python/src/tiledbsc/tiledb_group.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Dict, Optional, Sequence, List
+from typing import Dict, Optional, Sequence
 import time
 
 import tiledb
@@ -90,7 +90,7 @@ class TileDBGroup(TileDBObject):
         return tiledb.Group(self.uri, mode=mode, ctx=self._ctx)
 
     # XXX COMMENT
-    def _get_child_uris(self, member_names: List[str]) -> Dict[str, str]:
+    def _get_child_uris(self, member_names: Sequence[str]) -> Dict[str, str]:
         """
         Computes the URI for a child of the given object. For local disk, S3, and
         tiledb://.../s3://...  pre-creation URIs, this is simply the parent's URI, a slash, and the

--- a/apis/python/src/tiledbsc/tiledb_group.py
+++ b/apis/python/src/tiledbsc/tiledb_group.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from typing import Dict, Optional, Sequence
+import time
 
 import tiledb
 
@@ -85,7 +86,8 @@ class TileDBGroup(TileDBObject):
         # This works in with-open-as contexts because tiledb.Group has __enter__ and __exit__ methods.
         return tiledb.Group(self.uri, mode=mode, ctx=self._ctx)
 
-    def _get_child_uri(self, member_name: str) -> str:
+    # XXX COMMENT
+    def _get_child_uris(self, member_names: List[str]) -> Dict[str, str]:
         """
         Computes the URI for a child of the given object. For local disk, S3, and
         tiledb://.../s3://...  pre-creation URIs, this is simply the parent's URI, a slash, and the
@@ -95,18 +97,58 @@ class TileDBGroup(TileDBObject):
         """
         if not self.exists():
             # TODO: comment
-            return self.uri + "/" + member_name
+            return {member_name : self.uri + "/" + member_name for member_name in member_names}
+
+        answer = {}
+
         mapping = self._get_member_names_to_uris()
-        if member_name in mapping:
-            return mapping[member_name]
-        else:
-            # Truly a slash, not os.path.join:
-            # * If the client is Linux/Un*x/Mac, it's the same of course
-            # * On Windows, os.path.sep is a backslash but backslashes are _not_ accepted for S3 or
-            #   tiledb-cloud URIs, whereas in Windows versions for years now forward slashes _are_
-            #   accepted for local-disk paths.
-            # This means forward slash is acceptable in all cases.
+        for member_name in member_names:
+            if member_name in mapping:
+                answer[member_name] = mapping[member_name]
+            else:
+                # Truly a slash, not os.path.join:
+                # * If the client is Linux/Un*x/Mac, it's the same of course
+                # * On Windows, os.path.sep is a backslash but backslashes are _not_ accepted for S3 or
+                #   tiledb-cloud URIs, whereas in Windows versions for years now forward slashes _are_
+                #   accepted for local-disk paths.
+                # This means forward slash is acceptable in all cases.
+                answer[member_name] = self.uri + "/" + member_name
+
+        return answer
+
+    # XXX COMMENT
+    def _get_child_uri(self, member_name: str) -> str:
+        """
+        Computes the URI for a child of the given object. For local disk, S3, and
+        tiledb://.../s3://...  pre-creation URIs, this is simply the parent's URI, a slash, and the
+        member name.  For post-creation TileDB-Cloud URIs, this is computed from the parent's
+        information.  (This is because in TileDB Cloud, members have URIs like
+        tiledb://namespace/df584345-28b7-45e5-abeb-043d409b1a97.)
+        """
+        t1 = time.time()
+        print("--XXXENTER")
+        if not self.exists():
+            # TODO: comment
+            print("--XXXEXIT1 %.3f" % (time.time() - t1))
             return self.uri + "/" + member_name
+        with self._open() as G:
+            if member_name in G:
+                return G[member_name].uri
+            else:
+                return self.uri + "/" + member_name
+#        mapping = self._get_member_names_to_uris()
+#        if member_name in mapping:
+#            print("--XXXEXIT2 %.3f" % (time.time() - t1))
+#            return mapping[member_name]
+#        else:
+#            # Truly a slash, not os.path.join:
+#            # * If the client is Linux/Un*x/Mac, it's the same of course
+#            # * On Windows, os.path.sep is a backslash but backslashes are _not_ accepted for S3 or
+#            #   tiledb-cloud URIs, whereas in Windows versions for years now forward slashes _are_
+#            #   accepted for local-disk paths.
+#            # This means forward slash is acceptable in all cases.
+#            print("--XXXEXIT3 %.3f" % (time.time() - t1))
+#            return self.uri + "/" + member_name
 
     def _add_object(self, obj: TileDBObject, relative: Optional[bool] = None) -> None:
         """
@@ -142,7 +184,8 @@ class TileDBGroup(TileDBObject):
         if relative:
             child_uri = obj.name
         with self._open("w") as G:
-            G.add(uri=child_uri, relative=relative, name=obj.name)
+            retval = G.add(uri=child_uri, relative=relative, name=obj.name)
+            print("RETVAL ", retval)
         # See _get_child_uri. Key point is that, on TileDB Cloud, URIs change from pre-creation to
         # post-creation. Example:
         # * Upload to pre-creation URI tiledb://namespace/s3://bucket/something/something/somaname
@@ -151,6 +194,7 @@ class TileDBGroup(TileDBObject):
         # * Member pre-creation URI tiledb://namespace/s3://bucket/something/something/somaname/obs
         # * Member post-creation URI tiledb://somaname/e4de581a-1353-4150-b1f4-6ed12548e497
         obj.uri = self._get_child_uri(obj.name)
+        print("REMAP", child_uri, "TO", obj.uri)
 
     def _remove_object(self, obj: TileDBObject) -> None:
         self._remove_object_by_name(obj.name)

--- a/apis/python/src/tiledbsc/uns_group.py
+++ b/apis/python/src/tiledbsc/uns_group.py
@@ -143,7 +143,9 @@ class UnsGroup(TileDBGroup):
         # Must be done first, to create the parent directory
         self.create_unless_exists()
 
-        child_uris = self._get_child_uris(list(uns.keys()))  # See comments in that function
+        child_uris = self._get_child_uris(
+            list(uns.keys())
+        )  # See comments in that function
 
         for key in uns.keys():
             component_uri = child_uris[key]  # See comments in that function

--- a/apis/python/src/tiledbsc/uns_group.py
+++ b/apis/python/src/tiledbsc/uns_group.py
@@ -143,8 +143,10 @@ class UnsGroup(TileDBGroup):
         # Must be done first, to create the parent directory
         self.create_unless_exists()
 
+        child_uris = self._get_child_uris(list(uns.keys()))  # See comments in that function
+
         for key in uns.keys():
-            component_uri = self._get_child_uri(key)  # See comments in that function
+            component_uri = child_uris[key]  # See comments in that function
             value = uns[key]
 
             if key == "rank_genes_groups":

--- a/apis/python/src/tiledbsc/uns_group.py
+++ b/apis/python/src/tiledbsc/uns_group.py
@@ -143,12 +143,11 @@ class UnsGroup(TileDBGroup):
         # Must be done first, to create the parent directory
         self.create_unless_exists()
 
-        child_uris = self._get_child_uris(
-            list(uns.keys())
-        )  # See comments in that function
+        # See comments in _get_child_uris
+        child_uris = self._get_child_uris(list(uns.keys()))
 
         for key in uns.keys():
-            component_uri = child_uris[key]  # See comments in that function
+            component_uri = child_uris[key]
             value = uns[key]
 
             if key == "rank_genes_groups":

--- a/apis/python/tools/ingestor
+++ b/apis/python/tools/ingestor
@@ -231,8 +231,6 @@ def ingest_one(
                     f"Already exists; replacing: {output_path}"
                 )
                 shutil.rmtree(output_path)  # Overwrite
-                # TODO: COMMENT
-                soma = tiledbsc.SOMA(uri=output_path, soma_options=soma_options)
             else:
                 raise Exception(
                     "Internal coding error in --ifexists handling.", ifexists, "<"

--- a/apis/python/tools/ingestor
+++ b/apis/python/tools/ingestor
@@ -231,6 +231,8 @@ def ingest_one(
                     f"Already exists; replacing: {output_path}"
                 )
                 shutil.rmtree(output_path)  # Overwrite
+                # TODO: COMMENT
+                soma = tiledbsc.SOMA(uri=output_path, soma_options=soma_options)
             else:
                 raise Exception(
                     "Internal coding error in --ifexists handling.", ifexists, "<"


### PR DESCRIPTION
Analysis for various read & write operations on `tiledb://...` URIs reveals that:

* Core-to-REST-server requests appear in things like `tiledb.object_type`, `tiledb.group.Group`, etc.
* These have server-side latency
* There are server-side optimizations we can do, certainly, but also on the client side we can _batch_ and _cache_:
  * Getting group-element name-to-URI mappings takes about half a second per request whether we ask for one group member at a time, or for all group elements at once.
  * Once we've gotten a name-to-URI mapping -- or a construction of an object which contains such -- we can cache the result to avoid subsequent, redundant requests (with, of course, cache-invalidation logic in the right places)