### PR TITLE
Do not throw on "in" check on unpopulated collection

### DIFF
--- a/apis/python/src/tiledbsc/soma_collection.py
+++ b/apis/python/src/tiledbsc/soma_collection.py
@@ -139,6 +139,8 @@ class SOMACollection(TileDBGroup):
         """
         Implements `name in soco`
         """
+        if not self.exists():
+            return False
         with self._open("r") as G:
             return name in G
 


### PR DESCRIPTION
See #232 