### PR TITLE
Use macos-12 for CI due to GitHub brownout of macos-10.15

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-10.15, windows-2019]
+        os: [ubuntu-latest, macos-12, windows-2019]
         python-version: ['3.8']
 
     steps:


### PR DESCRIPTION
Today CI jobs are being canceled for this, so it's time to move up.

See also https://github.com/TileDB-Inc/TileDB-Cloud-Py/pull/320 for prior art -- thanks @thetorpedodog ! :) 
