### PR TITLE
Parallelize soma collection queries

### DIFF
--- a/apis/python/src/tiledbsc/soma_collection.py
+++ b/apis/python/src/tiledbsc/soma_collection.py
@@ -1,5 +1,5 @@
-from typing import Dict, Iterator, Optional, Sequence, Set, Union
 from concurrent.futures import ThreadPoolExecutor
+from typing import Dict, Iterator, Optional, Sequence, Set, Union
 
 import tiledb
 
@@ -243,7 +243,9 @@ class SOMACollection(TileDBGroup):
 
         soma_slices = []
         for f in soma_slice_futures:
-            soma_slices.append(f.result())
+            soma_slice = f.result()
+            if soma_slice is not None:  # linter appeasement
+                soma_slices.append(soma_slice)
         return SOMASlice.concat(soma_slices)
 
     # ----------------------------------------------------------------


### PR DESCRIPTION
Parallelize soma collection queries via threading. This works as a short term item for performance improvements. We have a number of additional changes in flight for Soma collections that will yield better and longer term improvements.