### PR TITLE
SOMA-list query option, and further thread-pool experiments

### DIFF
--- a/apis/python/src/tiledbsc/annotation_dataframe.py
+++ b/apis/python/src/tiledbsc/annotation_dataframe.py
@@ -200,6 +200,8 @@ class AnnotationDataFrame(TileDBArray):
         Implements the 'decode on read' partof our logic as noted in `dim_select()`.
         """
         futures = []
+        # Empirically we find this has a bit of a speed-up. Presumably that's because of some NumPy
+        # C++ code releasing the GIL.
         with ThreadPoolExecutor() as executor:
             for k in df:
                 future = executor.submit(

--- a/apis/python/src/tiledbsc/soma_collection.py
+++ b/apis/python/src/tiledbsc/soma_collection.py
@@ -252,50 +252,15 @@ class SOMACollection(TileDBGroup):
         needn't specify these; if they don't, you must.
         """
 
-        soma_slice_futures = []
-
-        with ThreadPoolExecutor(
-            max_workers=self._soma_options.max_thread_pool_workers
-        ) as executor:
-            for soma in self:
-                # E.g. querying for 'cell_type == "blood"' but this SOMA doesn't have a cell_type column in
-                # its obs at all.
-                if obs_query_string is not None and not soma.obs.has_attr_names(
-                    obs_attrs or []
-                ):
-                    continue
-                # E.g. querying for 'feature_name == "MT-CO3"' but this SOMA doesn't have a feature_name
-                # column in its var at all.
-                if var_query_string is not None and not soma.var.has_attr_names(
-                    var_attrs or []
-                ):
-                    continue
-
-                soma_slice_future = executor.submit(
-                    soma.query,
-                    obs_attrs=obs_attrs,
-                    var_attrs=var_attrs,
-                    obs_query_string=obs_query_string,
-                    var_query_string=var_query_string,
-                    obs_ids=obs_ids,
-                    var_ids=var_ids,
-                )
-                soma_slice_futures.append(soma_slice_future)
-
-        # Linter:
-        # Argument 1 to "concat" of "SOMASlice" has incompatible type
-        # "List[Future[Optional[SOMASlice]]]"; expected "Sequence[SOMASlice]" [arg-type]
-        #
-        # but printing type(soma_slice) in the loop, it's of type SOMASlice -- and:
-        # o we've done soma_slice_future.result()
-        # o we've checked not-None
-
-        soma_slices = []
-        for soma_slice_future in soma_slice_futures:
-            soma_slice = soma_slice_future.result()
-            if soma_slice is not None:
-                soma_slices.append(soma_slice)
-        return SOMASlice.concat(soma_slices)
+        return SOMA.queries(
+            list(self._get_all_somas().values()),
+            obs_attrs=obs_attrs,
+            obs_query_string=obs_query_string,
+            obs_ids=obs_ids,
+            var_attrs=var_attrs,
+            var_query_string=var_query_string,
+            var_ids=var_ids,
+        )
 
     # ----------------------------------------------------------------
     def find_unique_obs_values(self, obs_label: str) -> Set[str]:


### PR DESCRIPTION
The main point here is that the `query` method of `SOMACollection` doesn't make deep use of the `SOMACollection` object -- the latter is used there solely as a springboard to generate a list of `SOMA` objects. It ought to be possible to do a slice-query on a list of `SOMA` objects as well as a `SOMACollection`; it now is.

In addition to that code motion, a couple more thread-pool-executor experiments were tried; without significant benefit at this point as long as we're leveraging the (non-trivial) `to_anndata` and `anndata.concat` logic for slice-concatenation, as these appear to be pure Python and don't parallelize. (Future work on the `libtiledbsc` C++ library, as well as the upcoming `tiledbsoma` refactor, will make deeper use of Arrow along with GIL-releasing C++, and these will then provide opportunities for more parallelism in the slice-concatenator.)