### PR TITLE
Keystroke-saver method for add-X-layer

### DIFF
--- a/apis/python/src/tiledbsc/soma.py
+++ b/apis/python/src/tiledbsc/soma.py
@@ -17,7 +17,7 @@ from .raw_group import RawGroup
 from .soma_options import SOMAOptions
 from .soma_slice import SOMASlice
 from .tiledb_group import TileDBGroup
-from .types import Ids
+from .types import Ids, Matrix
 from .uns_group import UnsGroup
 
 
@@ -521,5 +521,5 @@ class SOMA(TileDBGroup):
         Populates the `X` or `raw.X` subgroup for a `SOMA` object.
         """
         self.X.add_layer_from_matrix_and_dim_values(
-            matrix, self.obs.index(), self.var.index(), layer_name
+            matrix, self.obs.ids(), self.var.ids(), layer_name
         )

--- a/apis/python/src/tiledbsc/soma.py
+++ b/apis/python/src/tiledbsc/soma.py
@@ -510,3 +510,16 @@ class SOMA(TileDBGroup):
             )
 
         return soma
+
+    # ----------------------------------------------------------------
+    def add_X_layer(
+        self,
+        matrix: Matrix,
+        layer_name: str = "data",
+    ) -> None:
+        """
+        Populates the `X` or `raw.X` subgroup for a `SOMA` object.
+        """
+        self.X.add_layer_from_matrix_and_dim_values(
+            matrix, self.obs.index(), self.var.index(), layer_name
+        )

--- a/apis/python/tests/test_add_layer.py
+++ b/apis/python/tests/test_add_layer.py
@@ -51,6 +51,12 @@ def test_add_layer(adata):
     csr2 = soma.X.data2.csr()
     assert csr2.shape == orig_shape
 
+    # Add X layer -- more user-friendly syntax
+    soma.add_X_layer(csr, "data3")
+
+    csr3 = soma.X.data3.csr()
+    assert csr3.shape == orig_shape
+
     # Add obsm matrix
     soma.obsm.add_matrix_from_matrix_and_dim_values(
         soma.obsm.X_tsne.df(), soma.obs_keys(), "voila"


### PR DESCRIPTION
Going through @aaronwolen 's tutorial notebook and porting it to Python, I realize this crucial method needs to be simpler for the user to keystroke