### PR TITLE
Set dataframe indices correctly on readback, if from R

### DIFF
--- a/apis/python/src/tiledbsc/annotation_dataframe.py
+++ b/apis/python/src/tiledbsc/annotation_dataframe.py
@@ -135,6 +135,10 @@ class AnnotationDataFrame(TileDBArray):
         #   >>> A.meta.items()
         #   (('__pandas_index_dims', '{"obs_id": "<U0"}'),)
         # so the set_index is already done for us.
+        #
+        # However if the data was written somehow else (e.g. by tiledbscr-r) then we do.
+        if isinstance(df.index, pd.RangeIndex) and self.dim_name in df.columns:
+            df.set_index(self.dim_name, inplace=True)
 
         # TODO: when UTF-8 attributes are queryable using TileDB-Py's QueryCondition API we can remove this.
         # This is the 'decode on read' part of our logic; in dim_select we have the 'encode on write' part.


### PR DESCRIPTION
Data written by `tiledbsc-py` or `tiledbsc-r` have compatible `obs` schemas -- for example:

```
ArraySchema(
  domain=Domain(*[
    Dim(name='obs_id', domain=(None, None), tile=None, dtype='|S0', var=True),
  ]),
  attrs=[
    Attr(name='orig.ident', dtype='ascii', var=True, nullable=False, filters=FilterList([ZstdFilter(level=-1), ])),
    Attr(name='nCount_RNA', dtype='float64', var=False, nullable=False, filters=FilterList([ZstdFilter(level=-1), ])),
    Attr(name='nFeature_RNA', dtype='int32', var=False, nullable=False, filters=FilterList([ZstdFilter(level=-1), ])),
    Attr(name='seurat_annotations', dtype='ascii', var=True, nullable=False, filters=FilterList([ZstdFilter(level=-1), ])),
  ],
  cell_order='row-major',
  tile_order='row-major',
  capacity=256,
  sparse=True,
  allows_duplicates=False,
)
```

however, reading in Python dataframes written by Python and R respectively we have:

```
>>> soma.obs.df()
                  n_genes  percent_mito  n_counts          louvain
obs_id
AAACATACAACCAC-1      781      0.030178    2419.0      CD4 T cells
AAACATTGAGCTAC-1     1352      0.037936    4903.0          B cells
AAACATTGATCAGC-1     1131      0.008897    3147.0      CD4 T cells
AAACCGTGCTTCCG-1      960      0.017431    2639.0  CD14+ Monocytes
AAACCGTGTATGCG-1      522      0.012245     980.0         NK cells
...                   ...           ...       ...              ...
TTTCGAACTCTCAT-1     1155      0.021104    3459.0  CD14+ Monocytes
TTTCTACTGAGGCA-1     1227      0.009294    3443.0          B cells
TTTCTACTTCCTCG-1      622      0.021971    1684.0          B cells
TTTGCATGAGAGGC-1      454      0.020548    1022.0          B cells
TTTGCATGCCTCAC-1      724      0.008065    1984.0      CD4 T cells

[2638 rows x 4 columns]
```

vs.

```
>>> soma.obs.df()
              obs_id orig.ident  nCount_RNA  nFeature_RNA seurat_annotations
0     AAACATACAACCAC     pbmc3k      2419.0           779       Memory CD4 T
1     AAACATTGAGCTAC     pbmc3k      4903.0          1352                  B
2     AAACATTGATCAGC     pbmc3k      3147.0          1129       Memory CD4 T
3     AAACCGTGCTTCCG     pbmc3k      2639.0           960         CD14+ Mono
4     AAACCGTGTATGCG     pbmc3k       980.0           521                 NK
...              ...        ...         ...           ...                ...
2695  TTTCGAACTCTCAT     pbmc3k      3459.0          1153         CD14+ Mono
2696  TTTCTACTGAGGCA     pbmc3k      3443.0          1224                  B
2697  TTTCTACTTCCTCG     pbmc3k      1684.0           622                  B
2698  TTTGCATGAGAGGC     pbmc3k      1022.0           452                  B
2699  TTTGCATGCCTCAC     pbmc3k      1984.0           723        Naive CD4 T

[2700 rows x 5 columns]
```

(note these are not identical SOMAs, hence the dims not identical).

It's a bug in `tiledbsc-py` (fixed on this PR) that `obs_id` is reading back as a column name rather than an index if the dataframe was written by `tiledbsc-r`.