### PR TITLE
Support update-write of SOMAs

### DIFF
--- a/apis/python/src/tiledbsc/tiledb_group.py
+++ b/apis/python/src/tiledbsc/tiledb_group.py
@@ -198,8 +198,11 @@ class TileDBGroup(TileDBObject):
         if relative:
             child_uri = obj.name
         self._cached_member_names_to_uris = None  # invalidate on add-member
+        with self._open("r") as G:
+            exists = obj.name in G
         with self._open("w") as G:
-            G.add(uri=child_uri, relative=relative, name=obj.name)
+            if not exists:
+                G.add(uri=child_uri, relative=relative, name=obj.name)
         # See _get_child_uri. Key point is that, on TileDB Cloud, URIs change from pre-creation to
         # post-creation. Example:
         # * Upload to pre-creation URI tiledb://namespace/s3://bucket/something/something/somaname

--- a/apis/python/src/tiledbsc/uns_array.py
+++ b/apis/python/src/tiledbsc/uns_array.py
@@ -5,6 +5,7 @@ import pandas as pd
 import scipy.sparse as sp
 import tiledb
 
+import tiledbsc.logging
 import tiledbsc.util as util
 
 from .logging import log_io
@@ -89,13 +90,15 @@ class UnsArray(TileDBArray):
             # Note arr.astype('str') does not lead to a successfuly tiledb.from_numpy.
             arr = np.array(arr, dtype="O")
 
-        # overwrite = False
-        # if self.exists:
-        #     overwrite = True
-        #     log_io(None, f"{self._indent}Re-using existing array {self.uri}")
-        # tiledb.from_numpy(uri=self.uri, array=arr, ctx=self._ctx, overwrite=overwrite)
-        # TODO: find the right syntax for update-in-place (tiledb.from_pandas uses `mode`)
-        tiledb.from_numpy(uri=self.uri, array=arr, ctx=self._ctx)
+        if self.exists():
+            tiledbsc.logging.logger.info(
+                f"{self._indent}Re-using existing array {self.uri}"
+            )
+            tiledb.from_numpy(
+                uri=self.uri, array=arr, mode="append", start_idx=0, ctx=self._ctx
+            )
+        else:
+            tiledb.from_numpy(uri=self.uri, array=arr, ctx=self._ctx)
 
         log_io(
             None,

--- a/apis/python/src/tiledbsc/uns_array.py
+++ b/apis/python/src/tiledbsc/uns_array.py
@@ -92,7 +92,7 @@ class UnsArray(TileDBArray):
 
         if self.exists():
             tiledbsc.logging.logger.info(
-                f"{self._indent}Re-using existing array {self.uri}"
+                f"{self._indent}Updating existing array {self.uri}"
             )
             tiledb.from_numpy(
                 uri=self.uri, array=arr, mode="append", start_idx=0, ctx=self._ctx

--- a/apis/python/tools/ingestor
+++ b/apis/python/tools/ingestor
@@ -47,6 +47,11 @@ def main():
         action="store_true",
     )
     parser.add_argument(
+        "-u",
+        help="Shorthand for `--ifexists update`",
+        action="store_true",
+    )
+    parser.add_argument(
         "-o",
         help="Specify output directory to contain the somas",
         type=str,
@@ -78,7 +83,7 @@ select `relative=True`. (This is the default.)
     parser.add_argument(
         "--ifexists",
         help="What to do if soma storage already exists. Default: continue.",
-        choices=["replace", "abort", "continue", "update_obs_and_var"],
+        choices=["replace", "abort", "continue", "update", "update_obs_and_var"],
         type=str,
         nargs=1,
     )
@@ -93,6 +98,8 @@ select `relative=True`. (This is the default.)
     if args.ifexists is None:
         if args.x:
             args.ifexists = ["replace"]
+        elif args.u:
+            args.ifexists = ["update"]
         else:
             args.ifexists = ["continue"]
 
@@ -217,9 +224,11 @@ def ingest_one(
                     f"Already exists; continuing: {output_path}"
                 )
                 return
+
             elif ifexists == "abort":
                 tiledbsc.logging.error(f"Already exists; aborting: {output_path}")
                 sys.exit(1)
+
             elif ifexists == "replace":
                 if output_path.startswith("s3://") or output_path.startswith(
                     "tiledb://"
@@ -231,6 +240,10 @@ def ingest_one(
                     f"Already exists; replacing: {output_path}"
                 )
                 shutil.rmtree(output_path)  # Overwrite
+
+            elif ifexists == "update":
+                tiledbsc.logging.logger.info(f"Already exists; updating: {output_path}")
+
             else:
                 raise Exception(
                     "Internal coding error in --ifexists handling.", ifexists, "<"


### PR DESCRIPTION
Heretofore, `from_anndata` / `from_hd5` would fail if the SOMA already existed. Now, those can be used to update a SOMA..

Note: this was the plan all along; it was blocked by a missing `TileDB-Py` feature which is now deployed, so it's OK to move forward now.