### PR TITLE
Support fmt that is system installed with spdlog

### DIFF
--- a/libtiledbsc/include/tiledbsc/logger_public.h
+++ b/libtiledbsc/include/tiledbsc/logger_public.h
@@ -38,9 +38,8 @@
 
 #include <stdexcept>  // for windows: error C2039: 'runtime_error': is not a member of 'std'
 
-#define FMT_HEADER_ONLY
-#include <spdlog/fmt/bundled/format.h>
-#include <spdlog/fmt/bundled/ostream.h>
+#include <spdlog/fmt/fmt.h>
+#include <spdlog/fmt/ostr.h>
 
 namespace tiledbsc {
 


### PR DESCRIPTION
This switches to use the highlevel spdlog fmt includes which automatically handles if fmt is bundled or unbundled.