### PR TITLE
Fix for MacOS localhost build

### DIFF
--- a/scripts/bld
+++ b/scripts/bld
@@ -16,6 +16,13 @@ export pybind11_DIR=$(python -m pybind11 --cmakedir)
 # remove existing build and install directories
 rm -rf build dist
 
+if [ $(uname) = "Darwin" ]; then
+    mkdir -p build
+    nproc=$(sysctl -n hw.ncpu)
+else
+    nproc=$(nproc)
+fi
+
 # add options for TileDB debug build
 if [ $BUILD_TYPE == "Debug" ]; then
   EXTRA_OPTS="-DFORCE_EXTERNAL_TILEDB=ON -DDOWNLOAD_TILEDB_PREBUILT=OFF -DTILEDB_S3=OFF"
@@ -24,6 +31,6 @@ else
 fi
 
 cmake -B build -S libtiledbsc -DCMAKE_BUILD_TYPE=${BUILD_TYPE} ${EXTRA_OPTS}
-#cmake --build build --target check-format
-cmake --build build -j $(nproc)
+cmake --build build --target check-format
+cmake --build build -j $nproc
 cmake --build build --target install-libtiledbsc


### PR DESCRIPTION
Build failed with

```
make[3]: *** No targets specified and no makefile found.  Stop.
```

which was because the build does `cd` to `build/libtilesbsc` which is an empty directory, while `cmake` outputs had been written to `libtiledbsc` rather than `build/libtiledbsc`, so `build/libtilebsc` was an empty directory.

Also note I found that in spite of this PR,  I needed to clean out `cmake` artifacts from `libtiledbsc` -- just a caveat for anyone else running into this issue.