### PR TITLE
tiledbsc.logging.info() by default for good uploader UX

### DIFF
--- a/apis/python/examples/uniformizer.py
+++ b/apis/python/examples/uniformizer.py
@@ -52,7 +52,7 @@ def main() -> int:
     args = parser.parse_args()
 
     if args.verbose:
-        tiledbsc.logging.info()
+        tiledbsc.logging.debug()
 
     uniformizer = Uniformizer(args.atlas_uri, args.allow_non_primary_data)
 

--- a/apis/python/src/tiledbsc/__init__.py
+++ b/apis/python/src/tiledbsc/__init__.py
@@ -36,6 +36,7 @@ from .annotation_matrix_group import AnnotationMatrixGroup
 from .annotation_pairwise_matrix_group import AnnotationPairwiseMatrixGroup
 from .assay_matrix import AssayMatrix
 from .assay_matrix_group import AssayMatrixGroup
+from .logging import info
 from .raw_group import RawGroup
 from .soma import SOMA
 from .soma_collection import SOMACollection
@@ -48,6 +49,9 @@ from .uns_array import UnsArray
 from .uns_group import UnsGroup
 from .util_ann import describe_ann_file
 from .util_tiledb import show_soma_schemas
+
+info()  # Good uploader-progress UX by default, especially for ingest of larger SOMAs
+del info  # cleanup
 
 __all__ = [
     "AnnotationMatrix",

--- a/apis/python/tools/ingestor
+++ b/apis/python/tools/ingestor
@@ -106,8 +106,9 @@ select `relative=True`. (This is the default.)
     write_soco = args.soco
     if args.debug:
         tiledbsc.logging.debug()
-    elif not args.quiet:
-        tiledbsc.logging.info()
+    elif args.quiet:
+        tiledbsc.logging.warning()
+    # else default is tiledbsc.logging.info() in our __init__.py
 
     if args.relative is None:
         rel_member_uris = None

--- a/apis/python/tools/outgestor
+++ b/apis/python/tools/outgestor
@@ -77,9 +77,11 @@ def main():
         if not os.path.exists(outdir):
             os.mkdir(outdir)
 
-    verbose = not args.quiet
-    if verbose:
-        tiledbsc.logging.info()
+    if args.debug:
+        tiledbsc.logging.debug()
+    elif args.quiet:
+        tiledbsc.logging.warning()
+    # else default is tiledbsc.logging.info() in our __init__.py
 
     soma = tiledbsc.SOMA(input_path)
     tiledbsc.io.to_h5ad(soma, output_path)


### PR DESCRIPTION
The first screenshot is currently the default, and is less-good UX since it gives the user no idea about the ETA or progress or even liveness.

The second screenshot is currently only opt-in via `tiledbsc.logging.info()`, and is good UX.

This PR makes the good UX the default UX.

<img width="956" alt="Screen Shot 2022-08-25 at 12 43 31 PM" src="https://user-images.githubusercontent.com/2008794/186729764-ae7a8d45-18e0-40f3-87fe-aa4ba837c3a4.png">

<img width="733" alt="Screen Shot 2022-08-25 at 12 51 02 PM" src="https://user-images.githubusercontent.com/2008794/186729786-08b87faf-539e-4827-aec1-8666f96ad373.png">

