### PR TITLE
Build and install libtiledbsc with pip install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,8 +14,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-12, windows-2019]
+        os: [ubuntu-22.04, macos-12, windows-2019]
         python-version: ['3.8']
+        include:
+          - runs-on: ubuntu-22.04
+            cc: gcc-11
+            cxx: g++-11
+          - runs-on: macos-12
+            cc: gcc-11
+            cxx: g++-11
 
     steps:
     - name: Checkout TileDB-SingleCell
@@ -27,7 +34,10 @@ jobs:
         python-version: ${{ matrix.python-version }}
 
     - name: Install Python packages
-      run: python -m pip install pytest typeguard apis/python
+      run: python -m pip install pytest pybind11 typeguard apis/python
+      env:
+        CC: ${{ matrix.cc }}
+        CXX: ${{ matrix.cxx }}
 
     - name: Run pytests
       run: python -m pytest apis/python/tests

--- a/.github/workflows/cpp-ci.yml
+++ b/.github/workflows/cpp-ci.yml
@@ -12,13 +12,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-#        os: [ubuntu-20.04, macos-11, windows-2019]
-        os: [ubuntu-20.04, macos-11]
+        os: [ubuntu-22.04, macos-12]
         python-version: ['3.8']
         include:
-          - runs-on: ubuntu-latest
-            cc: gcc-10
-            cxx: g++-10
+          - runs-on: ubuntu-22.04
+            cc: gcc-11
+            cxx: g++-11
+          - runs-on: macos-12
+            cc: gcc-11
+            cxx: g++-11
 
     steps:
     - name: 'Print env'
@@ -44,21 +46,7 @@ jobs:
     - name: Install Python packages
       shell: bash
       run: |
-        python -m pip install pytest pybind11 apis/python
-
-    - name: Build libtiledbsc
-      shell: bash
-      run: |
-        export pybind11_DIR=$(python -m pybind11 --cmakedir)
-        echo "pybind11_DIR is: ${pybind11_DIR}"
-        mkdir build
-        cmake -B ${GITHUB_WORKSPACE}/build -S ${GITHUB_WORKSPACE}/libtiledbsc -Dpybind11_DIR=${pybind11_DIR}
-        if [ "$RUNNER_OS" == "Linux" ]; then
-          cmake --build ${GITHUB_WORKSPACE}/build --target check-format
-        fi
-        cmake --build ${GITHUB_WORKSPACE}/build --config Release -j ${NUMBER_OF_PROCESSORS} 2>&1
-        cmake --build ${GITHUB_WORKSPACE}/build --config Release -j ${NUMBER_OF_PROCESSORS} -t install-libtiledbsc 2>&1
-        cmake --build ${GITHUB_WORKSPACE}/build/libtiledbsc --config Release -j ${NUMBER_OF_PROCESSORS} -t build_tests 2>&1
+        python -m pip install -v pytest pybind11 apis/python
       env:
         CC: ${{ matrix.cc }}
         CXX: ${{ matrix.cxx }}
@@ -72,10 +60,4 @@ jobs:
     - name: Run libtiledbsc tests
       shell: bash
       run: |
-        export PATH=${PATH}:${GITHUB_WORKSPACE}/build/externals/install/bin
-        pushd ${GITHUB_WORKSPACE}/build/libtiledbsc
-        ctest -C Release --verbose
-        cd -
-        export PYTHONPATH=$PWD/dist/lib
-        export LD_LIBRARY_PATH=$PWD/dist/lib
-        pytest -sv --durations=0 libtiledbsc
+        source ./scripts/test

--- a/apis/python/pyproject.toml
+++ b/apis/python/pyproject.toml
@@ -3,7 +3,7 @@ requires = [
     "setuptools>=42",
     "wheel",
     "setuptools_scm[toml]>=6.2",
-    "pybind11>=2.6.2"
+    "pybind11>=2.10.0"
 ]
 build-backend = "setuptools.build_meta"
 

--- a/apis/python/setup.py
+++ b/apis/python/setup.py
@@ -1,7 +1,139 @@
-# This is only used for `python setup.py develop` for local editable installs.
-# Otherwise one should use `pip install .` for local non-editable installs,
-# or `pip install tiledbsc` for PyPI installs.
-import setuptools
+# This file is enables building the libtiledbsc external package as part of the
+# tiledbsc module install process.
+#
+# Local non-editable install:
+#   `pip install .`
+#
+# Local editable install:
+#   `pip install -e .`
+#
+# Install from PyPI
+#   `pip install tiledbsc`
+#
+# Based on ideas from https://github.com/pybind/cmake_example
+# The `bld` script here is reused for pip install, CI, and local builds.
+
+# type: ignore
+
+import os
+import shutil
+import subprocess
+import sys
+
+from setuptools import Extension, find_packages, setup
+from setuptools.command.bdist_egg import bdist_egg
+from setuptools.command.build_ext import build_ext
+from wheel.bdist_wheel import bdist_wheel
+
+MODULE_NAME = "tiledbsc"
+EXT_NAME = "tiledbsc.libtiledbsc"
+
+
+def find_or_build(setuptools_cmd):
+    # TODO: support windows
+    if sys.platform.startswith("win32"):
+        return
+
+    # Setup paths
+    python_dir = os.path.abspath(os.path.dirname(__file__))
+    src_dir = f"{python_dir}/src/{MODULE_NAME}"
+    scripts_dir = f"{python_dir}/../../scripts"
+    lib_dir = f"{python_dir}/../../dist/lib"
+
+    # Call the build script if the install library directory does not exist
+    if not os.path.exists(lib_dir):
+        subprocess.check_call([f"{scripts_dir}/bld"])
+
+    # Copy native libs into the package dir so they can be found by package_data
+    package_data = []
+    for obj in [os.path.join(lib_dir, f) for f in os.listdir(lib_dir)]:
+        print(f"  copying file {obj} to {src_dir}")
+        shutil.copy(obj, src_dir)
+        package_data.append(os.path.basename(obj))
+
+    # Install shared libraries inside the Python module via package_data.
+    print(f"  adding to package_data: {package_data}")
+    setuptools_cmd.distribution.package_data.update({MODULE_NAME: package_data})
+
+
+def get_ext_modules():
+    # Workaround windows issue compiling an extension with no source files
+    if sys.platform.startswith("win32"):
+        return []
+    else:
+        return [CMakeExtension(EXT_NAME)]
+
+
+class CMakeExtension(Extension):
+    def __init__(self, name):
+        Extension.__init__(self, name, sources=[])
+
+
+class BuildExtCmd(build_ext):
+    def build_extensions(self):
+        find_or_build(self)
+        super().build_extensions()
+
+
+class BdistEggCmd(bdist_egg):
+    def run(self):
+        find_or_build(self)
+        bdist_egg.run(self)
+
+
+class BdistWheelCmd(bdist_wheel):
+    def run(self):
+        find_or_build(self)
+        bdist_wheel.run(self)
+
 
 if __name__ == "__main__":
-    setuptools.setup()
+    setup(
+        name=MODULE_NAME,
+        description="Python API for efficient storage and retrieval of single-cell data using TileDB",
+        author="TileDB, Inc.",
+        author_email="help@tiledb.io",
+        maintainer="TileDB, Inc.",
+        maintainer_email="help@tiledb.io",
+        url="https://github.com/single-cell-data/TileDB-SingleCell/apis/python",
+        license="MIT",
+        classifiers=[
+            "Intended Audience :: Developers",
+            "Intended Audience :: Information Technology",
+            "Intended Audience :: Science/Research",
+            "License :: OSI Approved :: MIT License",
+            "Programming Language :: Python",
+            "Topic :: Scientific/Engineering :: Bio-Informatics",
+            "Operating System :: Unix",
+            "Operating System :: POSIX :: Linux",
+            "Operating System :: MacOS :: MacOS X",
+            "Programming Language :: Python :: 3.7",
+            "Programming Language :: Python :: 3.8",
+            "Programming Language :: Python :: 3.9",
+        ],
+        package_dir={"": "src"},
+        packages=find_packages("src"),
+        zip_safe=False,
+        setup_requires=[
+            "setuptools>=18.0",
+            "setuptools_scm>=1.5.4",
+            "wheel>=0.30",
+            "pybind11>=2.10.0",
+            "setuptools_scm_git_archive",
+        ],
+        install_requires=[
+            "anndata",
+            "pandas",
+            "pyarrow",
+            "scanpy",
+            "scipy",
+            "tiledb>=0.17.0",
+        ],
+        python_requires=">=3.7",
+        ext_modules=get_ext_modules(),
+        cmdclass={
+            "build_ext": BuildExtCmd,
+            "bdist_egg": BdistEggCmd,
+            "bdist_wheel": BdistWheelCmd,
+        },
+    )

--- a/apis/python/src/tiledbsc/__init__.py
+++ b/apis/python/src/tiledbsc/__init__.py
@@ -68,3 +68,9 @@ __all__ = [
     "describe_ann_file",
     "show_soma_schemas",
 ]
+
+try:
+    from . import libtiledbsc  # type: ignore[attr-defined] # noqa: F401
+except ImportError:
+    # mask error to import libtiledbsc if it is not installed
+    pass

--- a/libtiledbsc/src/CMakeLists.txt
+++ b/libtiledbsc/src/CMakeLists.txt
@@ -56,8 +56,6 @@ add_library(TILEDB_SC_OBJECTS OBJECT
   ${CMAKE_CURRENT_SOURCE_DIR}/util.cc
   ${CMAKE_CURRENT_SOURCE_DIR}/thread_pool/thread_pool.cc
   ${CMAKE_CURRENT_SOURCE_DIR}/thread_pool/status.cc
-  ${CMAKE_CURRENT_SOURCE_DIR}/thread_pool/thread_pool.cc
-  ${CMAKE_CURRENT_SOURCE_DIR}/thread_pool/status.cc
 )
 
 message(WARNING "Building TileDB without deprecation warnings")
@@ -226,10 +224,14 @@ target_include_directories(tiledbsc-bin
 include(GNUInstallDirs)
 
 # Set rpath to be relative to the .so.
+# This allows tiledbsc shared objects to find the tiledb shared object in the
+# same directory, for example in the installed python module directory.
 if (APPLE)
   set_target_properties(tiledbsc PROPERTIES INSTALL_RPATH "@loader_path/")
+  set_target_properties(libtiledbsc PROPERTIES INSTALL_RPATH "@loader_path/")
 else()
   set_target_properties(tiledbsc PROPERTIES INSTALL_RPATH "$ORIGIN/")
+  set_target_properties(libtiledbsc PROPERTIES INSTALL_RPATH "$ORIGIN/")
 endif()
 
 set_property(
@@ -240,7 +242,8 @@ set_property(
 )
 
 install(
-  TARGETS tiledbsc tiledbsc-bin libtiledbsc
+#  TARGETS tiledbsc tiledbsc-bin libtiledbsc
+  TARGETS tiledbsc-bin libtiledbsc
   RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
   LIBRARY DESTINATION lib
   ARCHIVE DESTINATION lib

--- a/libtiledbsc/src/pyapi/CMakeLists.txt
+++ b/libtiledbsc/src/pyapi/CMakeLists.txt
@@ -1,19 +1,18 @@
 find_package(pybind11 REQUIRED)
 
 pybind11_add_module(libtiledbsc
-$<TARGET_OBJECTS:TILEDB_SC_OBJECTS>
-libtiledbsc.cc
+    $<TARGET_OBJECTS:TILEDB_SC_OBJECTS>
+    libtiledbsc.cc
 )
 
 target_compile_definitions(libtiledbsc PRIVATE
-  -DBUILD_COMMIT_HASH="${BUILD_COMMIT_HASH}"
+    -DBUILD_COMMIT_HASH="${BUILD_COMMIT_HASH}"
 )
 
 target_link_libraries(libtiledbsc
     PUBLIC
-    tiledbsc
     TileDB::tiledb_shared
-    )
+)
 
 target_include_directories(libtiledbsc
   PRIVATE

--- a/libtiledbsc/test/test_simple.py
+++ b/libtiledbsc/test/test_simple.py
@@ -1,6 +1,6 @@
 import pandas as pd
 import pyarrow as pa
-import libtiledbsc as sc
+import tiledbsc.libtiledbsc as sc
 import pytest
 import numpy as np
 import random

--- a/libtiledbsc/test/test_soma.py
+++ b/libtiledbsc/test/test_soma.py
@@ -1,7 +1,7 @@
 import os
 import pandas as pd
 import pyarrow as pa
-import libtiledbsc as sc
+import tiledbsc.libtiledbsc as sc
 
 VERBOSE = True
 

--- a/scripts/bld
+++ b/scripts/bld
@@ -15,9 +15,9 @@ export pybind11_DIR=$(python -m pybind11 --cmakedir)
 
 # remove existing build and install directories
 rm -rf build dist
+mkdir -p build
 
 if [ $(uname) = "Darwin" ]; then
-    mkdir -p build
     nproc=$(sysctl -n hw.ncpu)
 else
     nproc=$(nproc)
@@ -25,12 +25,16 @@ fi
 
 # add options for TileDB debug build
 if [ $BUILD_TYPE == "Debug" ]; then
-  EXTRA_OPTS="-DFORCE_EXTERNAL_TILEDB=ON -DDOWNLOAD_TILEDB_PREBUILT=OFF -DTILEDB_S3=OFF"
+  EXTRA_OPTS="-DFORCE_EXTERNAL_TILEDB=ON -DDOWNLOAD_TILEDB_PREBUILT=OFF"
 else
   EXTRA_OPTS=""
 fi
 
 cmake -B build -S libtiledbsc -DCMAKE_BUILD_TYPE=${BUILD_TYPE} ${EXTRA_OPTS}
-cmake --build build --target check-format
+
+# check format on Linux
+if [ $(uname) = "Linux" ]; then
+  cmake --build build --target check-format
+fi
 cmake --build build -j $nproc
 cmake --build build --target install-libtiledbsc

--- a/scripts/test
+++ b/scripts/test
@@ -9,15 +9,18 @@ set -eu -o pipefail
 # cd to the top level directory of the repo
 cd $(git rev-parse --show-toplevel)
 
+# Set env for pybind11 cmake
+export pybind11_DIR=$(python -m pybind11 --cmakedir)
+
+# Build the tests
 cmake --build build/libtiledbsc --target build_tests -j $(nproc)
 
+# Run unit tests
 cd build/libtiledbsc
 ctest -C Release --verbose
 
-# Run python API tests without installing
+# Run python tests
 cd -
-export PYTHONPATH=$PWD/dist/lib
-export LD_LIBRARY_PATH=$PWD/dist/lib
 pytest -v --durations=0 libtiledbsc
 
 # Generate coverage report


### PR DESCRIPTION
Build and install the `libtiledbsc` native library as part of the pip install process.
* Local non-editable install: `pip install .`
* Local editable install: `pip install -e .`

The `./scripts/bld` script is reused for pip install, CI, and local builds.